### PR TITLE
improve workshop flexibility with variable name for Databricks SQL wa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2026-04-20
+
+### Fixed
+
+- **SQL Warehouse lookup**: Exposed `databricks_sql_warehouse_name` variable in AWS and Azure root modules so participants can override the default warehouse name (`Serverless Starter Warehouse`) when their workspace uses a different name
+- **Troubleshooting**: Added "SQL Warehouse Not Found During Terraform Apply" entry to `troubleshooting.md` and linked it from LAB2
+
 ## [0.12.0] - 2026-04-13
 
 ### Added

--- a/labs/self-service/LAB2_cloud_deployment/LAB2.md
+++ b/labs/self-service/LAB2_cloud_deployment/LAB2.md
@@ -122,6 +122,8 @@ docker-compose run --rm terraform -c "terraform output"
 > If you encounter a `500 Internal Server Error` when creating the Databricks external location, this is a transient error due to IAM propagation delays. The `terraform-apply-wrapper-with-retry.sh` script will automatically retry until successful.
 >
 > See [this section](../../shared/troubleshooting.md#transient-500-error-during-external-location-creation) of the Troubleshooting Guide for more details.
+>
+> If you see `can't find SQL warehouse with the name 'Serverless Starter Warehouse'`, see the [SQL Warehouse Not Found](../../shared/troubleshooting.md#sql-warehouse-not-found-during-terraform-apply) troubleshooting entry.
 
 ### Step 2: Verify Data Generation
 

--- a/labs/shared/troubleshooting.md
+++ b/labs/shared/troubleshooting.md
@@ -391,6 +391,42 @@ Since this is a transient error, the IAM configuration is correct - it just need
 
 ## 🧱 Databricks
 
+### SQL Warehouse Not Found During Terraform Apply
+
+**Issue:**
+
+When running `terraform apply`, you encounter an error like:
+
+```
+Error: cannot read sql warehouse: cannot read data sql warehouse: can't find SQL warehouse with the name 'Serverless Starter Warehouse'
+
+  with module.databricks.data.databricks_sql_warehouse.main[0],
+  on ../modules/databricks/main.tf line 186, in data "databricks_sql_warehouse" "main":
+ 186: data "databricks_sql_warehouse" "main" {
+```
+
+**Why This Happens:**
+
+Terraform tries to look up an existing SQL warehouse by name (`Serverless Starter Warehouse` by default). This fails when:
+
+1. **The warehouse doesn't exist yet** — Databricks auto-provisions the Serverless Starter Warehouse when a user first logs into the workspace UI. If you haven't logged in yet, it won't exist.
+2. **The warehouse has a different name** — Your workspace may use a different warehouse name (e.g., `Starter Warehouse`).
+3. **Serverless compute is not enabled** — The Databricks account admin hasn't enabled serverless compute for your workspace region.
+
+**Resolution:**
+
+1. **Log into the Databricks workspace UI first** — This triggers auto-provisioning of the default SQL warehouse. Then re-run `terraform apply`.
+
+2. **Override the warehouse name** — If your workspace uses a different warehouse name, uncomment or add the following to your `terraform.tfvars`:
+
+   ```hcl
+   databricks_sql_warehouse_name = "Your Warehouse Name"
+   ```
+
+   You can find available warehouse names in the Databricks workspace under **SQL Warehouses** in the left navigation.
+
+3. **Verify serverless is enabled** — Check with your Databricks account admin that serverless compute is enabled for your workspace region.
+
 ### Serverless Starter Warehouse — Not Authorized to Create Clusters
 
 **Issue:**

--- a/terraform/aws-demo/sample-tfvars
+++ b/terraform/aws-demo/sample-tfvars
@@ -19,3 +19,6 @@ databricks_account_id                      = ""  # Required for IAM trust policy
 databricks_user_email                      = ""  # Your Databricks user email for granting permissions
 databricks_service_principal_client_id     = ""  # Service Principal Application ID (created manually - see LAB1.md)
 databricks_service_principal_client_secret = ""  # Service Principal OAuth Secret (created manually - see LAB1.md)
+
+# Uncomment and set if your Databricks workspace uses a different SQL warehouse name:
+# databricks_sql_warehouse_name = "Serverless Starter Warehouse"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -217,6 +217,7 @@ module "databricks" {
   sso_email                   = var.databricks_sso_email
   service_principal_client_id = var.databricks_service_principal_client_id
   kafka_cluster_id            = module.confluent_platform.kafka_cluster_id
+  sql_warehouse_name          = var.databricks_sql_warehouse_name
 
   depends_on = [module.iam, module.s3, module.tableflow]
 }

--- a/terraform/aws/sample-tfvars
+++ b/terraform/aws/sample-tfvars
@@ -20,6 +20,9 @@ databricks_user_email                      = ""  # Your Databricks user email fo
 databricks_service_principal_client_id     = ""  # Service Principal Application ID (created manually - see LAB1.md)
 databricks_service_principal_client_secret = ""  # Service Principal OAuth Secret (created manually - see LAB1.md)
 
+# Uncomment and set if your Databricks workspace uses a different SQL warehouse name:
+# databricks_sql_warehouse_name = "Serverless Starter Warehouse"
+
 # ===============================
 # AWS Overrides
 # ===============================

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -282,6 +282,12 @@ variable "databricks_service_principal_client_secret" {
   }
 }
 
+variable "databricks_sql_warehouse_name" {
+  description = "Name of the Databricks SQL warehouse to look up (must already exist in the workspace)"
+  type        = string
+  default     = "Serverless Starter Warehouse"
+}
+
 variable "allowed_cidr_blocks" {
   description = "List of CIDR blocks allowed to access Oracle DB and SSH"
   type        = list(string)

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -285,6 +285,7 @@ module "databricks" {
   sso_email                   = var.databricks_sso_email
   service_principal_client_id = var.databricks_service_principal_client_id
   kafka_cluster_id            = module.confluent_platform.kafka_cluster_id
+  sql_warehouse_name          = var.databricks_sql_warehouse_name
 }
 
 # ===============================

--- a/terraform/azure/sample-tfvars
+++ b/terraform/azure/sample-tfvars
@@ -31,6 +31,9 @@ databricks_user_email                      = ""
 databricks_service_principal_client_id     = ""
 databricks_service_principal_client_secret = ""
 
+# Uncomment and set if your Databricks workspace uses a different SQL warehouse name:
+# databricks_sql_warehouse_name = "Serverless Starter Warehouse"
+
 # ===============================
 # Optional: PostgreSQL Overrides
 # ===============================

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -186,6 +186,12 @@ variable "databricks_service_principal_client_secret" {
   sensitive   = true
 }
 
+variable "databricks_sql_warehouse_name" {
+  description = "Name of the Databricks SQL warehouse to look up (must already exist in the workspace)"
+  type        = string
+  default     = "Serverless Starter Warehouse"
+}
+
 # ---------------------
 # WSA integration variables (defaults preserve backward compatibility for self-service)
 # ---------------------


### PR DESCRIPTION
## [0.12.1] - 2026-04-20

### Fixed

- **SQL Warehouse lookup**: Exposed `databricks_sql_warehouse_name` variable in AWS and Azure root modules so participants can override the default warehouse name (`Serverless Starter Warehouse`) when their workspace uses a different name
- **Troubleshooting**: Added "SQL Warehouse Not Found During Terraform Apply" entry to `troubleshooting.md` and linked it from LAB2