### PR TITLE
Feat/azure demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ terraform/aws-config/*
 !terraform/aws-config/.gitkeep
 terraform/aws-demo/aws-config/*
 !terraform/aws-demo/aws-config/.gitkeep
+
+# Local testing directory
+terraform-wsa-test/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-07-15
+
+### Added
+
+- **Azure Demo Mode**: New `terraform/azure-demo/` root that mirrors AWS demo automation on Azure (catalog integration, `denormalized_hotel_bookings` Flink Materialized Table, Tableflow topic enablement, marketing notebook), with shared-infra / WSA support
+- **WSA Demo Specs**: Added `wsa-spec-aws-demo.yaml` and `wsa-spec-azure-demo.yaml` pointing at the demo Terraform roots while keeping shared infra, isolation, and credential output patterns from the workshop specs
+- **Tableflow Topics (Azure)**: Extended `confluent-tableflow-topics` with Azure ADLS Gen2 (`azure_data_lake_storage_gen_2`) and an `enable_reviews_with_sentiment` flag
+- **Flink CTAS options**: Added `enable_reviews_with_sentiment` to `confluent-flink-ctas` so Azure can skip `AI_SENTIMENT` (AWS-only since 2026-03-19)
+
+### Changed
+
+- **AWS Demo Mode (WSA)**: Upgraded `terraform/aws-demo/` for shared-infra mode (`shared_*` vars, CDC topic wiring, WSA credential outputs) so it works with `wsa build`
+- **Flink Materialized Tables**: `confluent-flink-ctas` now fully qualifies source tables as `` `env`.`cluster`.`topic` `` (materialized tables lack `sql.current-catalog` / `sql.current-database`) and selects `check_in`/`check_out` casting by source — `TO_TIMESTAMP_LTZ` for Avro epoch millis (self-service) vs `CAST AS DATE` for CDC `TIMESTAMP_LTZ` (WSA / instructor-led)
+- **Docs**: README and `labs/demo` updated for AWS + Azure demo roots (`aws-demo` / `azure-demo`), Azure auth, resource differences, and `AI_SENTIMENT` / `hotel_performance` skip on Azure
+
 ## [0.13.1] - 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ By the end of this workshop, you will have constructed a sophisticated data pipe
 
 1. **Captures Real-Time Customer Behavior**: Set up PostgreSQL CDC to capture customer and hotel data changes, plus generate realistic clickstream, booking, and review data using Java Datagen
 2. **Processes Streaming Data with AI**: Use Confluent Cloud for Apache Flink SQL to denormalize bookings with temporal joins and enrich hotel reviews with aspect-based sentiment analysis (`AI_SENTIMENT` for cleanliness, amenities, and service)
-3. **Streams to Delta Lake**: Leverage Confluent Tableflow to automatically sync processed data streams as Delta tables in AWS S3
+3. **Streams to Delta Lake**: Leverage Confluent Tableflow to automatically sync processed data streams as Delta tables in AWS S3 or Azure ADLS2
 4. **Generates AI-Driven Insights**: Use Databricks Genie to analyze booking patterns, customer preferences, and hotel performance metrics
 5. **Creates Personalized Campaigns**: Deploy AI agents in Databricks that identify underperforming hotels with good customer satisfaction, generate targeted social media content based on customer review analysis, and create lists of potential customers for marketing outreach
 
 ### 🎓 Key Learning Outcomes
 
-- **Infrastructure as Code**: Deploy complex multi-cloud resources (AWS, Confluent Cloud, Databricks) using Terraform
+- **Infrastructure as Code**: Deploy complex multi-cloud resources (AWS or Azure, Confluent Cloud, Databricks) using Terraform
 - **Change Data Capture**: Implement PostgreSQL CDC Connector for real-time database change streaming
 - **Stream Processing**: Build sophisticated Flink SQL queries for real-time data enrichment and AI model integration
 - **Data Lake Integration**: Use Tableflow to seamlessly bridge streaming data and analytics platforms
@@ -212,7 +212,7 @@ erDiagram
 ### Cloud Platforms
 
 - **[Confluent Cloud](https://confluent.io/)**: Fully managed Apache Kafka service
-- **[AWS](https://aws.amazon.com/)**: Primary cloud provider (EC2, S3, VPC, Bedrock)
+- **[AWS](https://aws.amazon.com/)** / **[Azure](https://azure.microsoft.com/)**: Cloud providers for compute, networking, and Delta Lake storage (S3 or ADLS Gen2)
 - **[Databricks](https://databricks.com/)**: Unified analytics platform for big data and ML
 
 ### AI/ML Services
@@ -276,15 +276,19 @@ This workshop supports three modes. Choose the path that matches your situation:
 > This builds on the self-service mode by automating almost all of the manual steps that enable the real-time AI marketing pipeline. This **demo** mode can be used for short-term, long-term, and even "always-on" demos.
 >
 > Use it to show quick and immediate value with minimal in-product (Confluent Cloud, Databricks) set up.
+>
+> Demo Terraform roots: [`terraform/aws-demo`](./terraform/aws-demo) (AWS) and [`terraform/azure-demo`](./terraform/azure-demo) (Azure). For automated multi-account provisioning, use [`wsa-spec-aws-demo.yaml`](./wsa-spec-aws-demo.yaml) or [`wsa-spec-azure-demo.yaml`](./wsa-spec-azure-demo.yaml) with WSA.
+>
+> **Azure note:** `AI_SENTIMENT` / `reviews_with_sentiment` and the `hotel_performance` view are AWS-only today. Azure demo still provisions denormalized bookings, clickstream Tableflow, Unity Catalog integration, and the marketing notebook.
 
 | Lab | Duration | Details |
 |-----|----------|-------------|
-| [LAB 0: Prerequisites](./labs/demo/LAB0_prerequisites/LAB0.md) | ~10 min | **Set up prerequisites**: create cloud accounts, install Git and Docker, clone the repo, build Docker images. |
-| [LAB 1: Account Setup](./labs/demo/LAB1_account_setup/LAB1.md) | ~15 min | **Configure cloud platform accounts**: set up Confluent Cloud API keys, configure Databricks service principal, establish AWS credentials. |
-| [LAB 2: Deploy and Observe](./labs/demo/LAB2_deploy_and_observe/LAB2.md) | ~25 min | **Deploy everything with Terraform**: one `terraform apply` provisions AWS, Confluent Cloud, Flink CTAS, Tableflow, Unity Catalog integration, and Databricks notebook. Guided tour of the pipeline. |
-| [LAB 3: Analytics & AI](./labs/demo/LAB3_analytics_ai/LAB3.md) | ~30 min | **Generate insights**: explore pre-created hotel performance and sentiment analytics, use Databricks Genie, run the pre-imported marketing agent notebook. |
+| [LAB 0: Prerequisites](./labs/demo/LAB0_prerequisites/LAB0.md) | ~10 min | **Set up prerequisites**: create cloud accounts, install Git and Docker, clone the repo, build Docker images (AWS or Azure). |
+| [LAB 1: Account Setup](./labs/demo/LAB1_account_setup/LAB1.md) | ~15 min | **Configure cloud platform accounts**: set up Confluent Cloud API keys, configure Databricks service principal, establish AWS or Azure credentials. |
+| [LAB 2: Deploy and Observe](./labs/demo/LAB2_deploy_and_observe/LAB2.md) | ~25 min | **Deploy everything with Terraform**: one `terraform apply` provisions cloud infra, Confluent Cloud, Flink Materialized Tables, Tableflow, Unity Catalog integration, and Databricks notebook. Guided tour of the pipeline. |
+| [LAB 3: Analytics & AI](./labs/demo/LAB3_analytics_ai/LAB3.md) | ~30 min | **Generate insights**: explore pre-created analytics (sentiment / `hotel_performance` on AWS), use Databricks Genie, run the pre-imported marketing agent notebook. |
 | [LAB 4: Cleanup](./labs/demo/LAB4_cleanup/LAB4.md) | ~5 min | **Clean up resources**: `terraform destroy` handles everything including Tableflow. |
-| [Optional: Data Governance](./labs/demo/LAB_data_governance/LAB_data_governance.md) | ~10 min | **Demonstrate data quality rules**: observe pre-deployed CEL rules, live DQR demo with `/test-dqr` on EC2, DLQ observation. |
+| [Optional: Data Governance](./labs/demo/LAB_data_governance/LAB_data_governance.md) | ~10 min | **Demonstrate data quality rules**: observe pre-deployed CEL rules, live DQR demo with `/test-dqr` on AWS EC2, DLQ observation. |
 
 ### Additional Resources
 
@@ -294,8 +298,7 @@ This workshop supports three modes. Choose the path that matches your situation:
 
 ## 🏁 Conclusion
 
-Congratulations, you have completed this hands-on workshop on creating a streaming AI agent on AWS with Confluent and Databricks!
-
+Congratulations, you have completed this hands-on workshop on creating a streaming AI agent on AWS or Azure with Confluent and Databricks!
 > [!IMPORTANT]
 > **Your Feedback Helps!**
 >

--- a/labs/demo/LAB0_prerequisites/LAB0.md
+++ b/labs/demo/LAB0_prerequisites/LAB0.md
@@ -10,7 +10,9 @@ If you want to learn more about why or when you would want to use **demo** mode,
 
 - **Confluent Cloud account** with admin privileges - [sign up for a free trial](https://www.confluent.io/confluent-cloud/tryfree?utm_campaign=tm.fm-ams_cd.Build-an-AI-Pipeline-Workshop-2025-Q2&utm_term=workshop&campaign_id=701Uz00000fEQeEIAW&utm_source=zoom&utm_medium=workshop)
 - **Databricks account** and existing workspace - paid or [free edition account](https://login.databricks.com/?intent=SIGN_UP&provider=DB_FREE_TIER) are strongly recommended. [Free trial account](https://docs.databricks.com/aws/en/getting-started/express-setup) sometimes experience data syncing issues with this workshop, so we recommend that you use **paid** or **free edition** accounts instead.
-- **AWS account** with permissions to create cloud resources (EC2, S3, VPC, IAM)
+- **Cloud account** for the demo you choose:
+  - **AWS**: permissions to create EC2, S3, VPC, and IAM resources (`terraform/aws-demo`)
+  - **Azure**: permissions to create Resource Groups, Storage (ADLS Gen2), PostgreSQL Flexible Server, and related RBAC (`terraform/azure-demo`)
 
 > [!IMPORTANT]
 > **Payment Method or Promo Code Required for Confluent Cloud**
@@ -135,12 +137,23 @@ sudo usermod -aG docker $USER
 
 ## Step 2: Build Terraform Docker Image
 
-Navigate into the workshop's demo Terraform directory and build the container:
+Choose your cloud demo directory, then build the container:
+
+**AWS:**
 
 ```sh
 cd workshop-tableflow-databricks/terraform/aws-demo
 docker-compose build
 ```
+
+**Azure:**
+
+```sh
+cd workshop-tableflow-databricks/terraform/azure-demo
+docker-compose build
+```
+
+Use the same directory for the rest of the demo labs (`LAB 1`–`LAB 4`).
 
 You should see output showing the container being built:
 
@@ -155,6 +168,11 @@ You should see output showing the container being built:
 > **First-Time Build**
 >
 > The initial build may take a few minutes. Subsequent uses leverage cached layers and should complete in seconds.
+
+> [!NOTE]
+> **Azure and AI sentiment**
+>
+> Azure demo skips `reviews_with_sentiment` and the `hotel_performance` view because `AI_SENTIMENT` is currently AWS-only. See the [Confluent Cloud release notes](https://docs.confluent.io/cloud/current/release-notes/index.html#march-19-2026).
 
 ## What's Next
 

--- a/labs/demo/LAB1_account_setup/LAB1.md
+++ b/labs/demo/LAB1_account_setup/LAB1.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In this lab you will configure all cloud platform accounts and credentials needed to deploy the full River Hotels pipeline in demo mode. This is identical to the self-service account setup.
+In this lab you will configure all cloud platform accounts and credentials needed to deploy the full River Hotels pipeline in demo mode. This is identical to the self-service account setup, except you work in either `terraform/aws-demo` or `terraform/azure-demo` (from LAB 0).
 
 ### What You'll Accomplish
 
@@ -10,7 +10,7 @@ By the end of this lab, you will have:
 
 1. **Configured Confluent Cloud**: Created API keys for cloud resource management
 2. **Setup Databricks Account**: Configured account access, created service principals, and enabled external data access
-3. **Authenticated with AWS**: Set up AWS credentials for Terraform
+3. **Authenticated with your cloud provider**: Set up AWS or Azure credentials for Terraform
 
 ### Prerequisites
 
@@ -20,7 +20,7 @@ Complete **[LAB 0: Prerequisites](../LAB0_prerequisites/LAB0.md)** before starti
 
 ### Step 1: Create Terraform Variables File
 
-1. Ensure you are in the `terraform/aws-demo` directory
+1. Ensure you are in the demo directory you chose in LAB 0 (`terraform/aws-demo` or `terraform/azure-demo`)
 2. Copy the sample variables file:
 
 ```sh
@@ -31,7 +31,9 @@ cp sample-tfvars terraform.tfvars
 
 ### Step 2: Configure Cloud Prefix and Region
 
-Pick a short, memorable prefix (like your initials) and set your AWS region:
+Pick a short, memorable prefix (like your initials) and set your cloud region:
+
+**AWS** (`us-east-1`, `us-west-2`, etc.):
 
 ```hcl
 confluent_cloud_email = "you@example.com"
@@ -39,9 +41,17 @@ prefix                = "neo"
 cloud_region          = "us-east-1"
 ```
 
+**Azure** (use an Azure region that matches your Databricks workspace, e.g. `eastus2`):
+
+```hcl
+confluent_cloud_email = "you@example.com"
+prefix                = "neo"
+cloud_region          = "eastus2"
+```
+
 ### Step 3: Configure Confluent Cloud Account
 
-Follow the same steps as the [self-service LAB1 Step 3](../self-service/LAB1_account_setup/LAB1.md#step-3-configure-confluent-cloud-account) to create a **Cloud resource management** API key.
+Follow the same steps as the [self-service LAB1 Step 3](../../self-service/LAB1_account_setup/LAB1.md#step-3-configure-confluent-cloud-account) to create a **Cloud resource management** API key.
 
 Add the key and secret to your `terraform.tfvars`:
 
@@ -52,7 +62,7 @@ confluent_cloud_api_secret = "YOUR_SECRET"
 
 ### Step 4: Configure Databricks Account
 
-Follow the same steps as the [self-service LAB1 Step 4](../self-service/LAB1_account_setup/LAB1.md#step-4-configure-databricks-account) to:
+Follow the same steps as the [self-service LAB1 Step 4](../../self-service/LAB1_account_setup/LAB1.md#step-4-configure-databricks-account) to:
 
 1. Get your **Databricks workspace URL** and **user email**
 2. Create a **Service Principal** with an OAuth secret
@@ -69,14 +79,38 @@ databricks_service_principal_client_id     = "YOUR_SP_CLIENT_ID"
 databricks_service_principal_client_secret = "YOUR_SP_SECRET"
 ```
 
-### Step 5: Configure AWS Account
+### Step 5: Configure Cloud Provider Credentials
 
-Follow the same steps as the [self-service LAB1 Step 4 (AWS)](../self-service/LAB1_account_setup/LAB1.md#step-4-configure-aws-account) to configure AWS credentials.
+#### AWS (`terraform/aws-demo`)
+
+Follow the same steps as the [self-service LAB1 Step 4 (AWS)](../../self-service/LAB1_account_setup/LAB1.md#step-4-configure-aws-account) to configure AWS credentials.
 
 Verify AWS credentials work inside the Docker container:
 
 ```sh
 docker-compose run --rm terraform -c "aws configure list"
+```
+
+#### Azure (`terraform/azure-demo`)
+
+The Azure Terraform container accepts credentials in this order:
+
+1. **Service principal env vars** (recommended for automation): `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`, `ARM_SUBSCRIPTION_ID`
+2. **Host `az login`**: `~/.azure` is mounted into the container
+
+Export the service principal variables in the same terminal where you run `docker-compose`, or run `az login` on the host before building/running.
+
+If your `sample-tfvars` includes Azure subscription/tenant overrides, set them as well:
+
+```hcl
+azure_subscription_id = "YOUR_SUBSCRIPTION_ID"
+azure_tenant_id       = "YOUR_TENANT_ID"
+```
+
+Verify Azure auth inside the container:
+
+```sh
+docker-compose run --rm terraform -c "az account show"
 ```
 
 ## Conclusion

--- a/labs/demo/LAB2_deploy_and_observe/LAB2.md
+++ b/labs/demo/LAB2_deploy_and_observe/LAB2.md
@@ -2,22 +2,27 @@
 
 ## Overview
 
-This is where demo mode shines. A single `terraform apply` provisions the entire real-time AI marketing pipeline -- from AWS infrastructure to Confluent Cloud data streaming, Flink stream processing, Tableflow Delta Lake synchronization, and Databricks Unity Catalog integration.
+This is where demo mode shines. A single `terraform apply` provisions the entire real-time AI marketing pipeline -- from cloud infrastructure to Confluent Cloud data streaming, Flink stream processing, Tableflow Delta Lake synchronization, and Databricks Unity Catalog integration.
 
 ### What Terraform Creates
 
 By the end of this lab, `terraform apply` will have provisioned:
 
-| Layer | Resources |
-|-------|-----------|
-| **AWS** | VPC, EC2 instance with PostgreSQL + data generator, S3 bucket, IAM role |
-| **Confluent Cloud** | Environment, Standard Kafka cluster, Schema Registry, Flink compute pool, service account, API keys |
-| **CDC Pipeline** | PostgreSQL CDC connector (Debezium), producing `riverhotel.cdc.customer` and `riverhotel.cdc.hotel` topics |
-| **Data Generator** | Produces `clickstream`, `bookings`, and `reviews` directly to Kafka with Avro schemas |
-| **Flink Statements** | ALTER TABLE statements (watermarks, changelog modes, retention) + Materialized Tables for `denormalized_hotel_bookings` and `reviews_with_sentiment` |
-| **Data Contracts** | Clickstream schema with CEL data quality rule (`validateClickstreamAction`), DLQ topic (`invalid_clickstream_events`) |
-| **Tableflow** | S3 provider integration, Unity Catalog integration, Tableflow enabled on `clickstream`, `denormalized_hotel_bookings`, and `reviews_with_sentiment` |
-| **Databricks** | Storage credential, external location, Unity Catalog, marketing agent notebook imported |
+| Layer | AWS (`aws-demo`) | Azure (`azure-demo`) |
+|-------|------------------|----------------------|
+| **Cloud infra** | VPC, EC2 (PostgreSQL + data generator), S3, IAM | Resource Group, ADLS Gen2, PostgreSQL Flexible Server, data generator |
+| **Confluent Cloud** | Environment, Standard Kafka cluster, Schema Registry, Flink compute pool, service account, API keys | Same |
+| **CDC Pipeline** | PostgreSQL CDC → `riverhotel.cdc.customer` / `riverhotel.cdc.hotel` | Same |
+| **Data Generator** | `clickstream`, `bookings`, `reviews` (Avro) | Same |
+| **Flink** | Materialized Tables: `denormalized_hotel_bookings` **and** `reviews_with_sentiment` | `denormalized_hotel_bookings` only (`AI_SENTIMENT` is AWS-only) |
+| **Data Contracts** | Clickstream CEL rule + DLQ | Same |
+| **Tableflow** | S3 + UC integration; topics: clickstream, denormalized bookings, **reviews_with_sentiment** | ADLS Gen2 + UC; topics: clickstream, denormalized bookings |
+| **Databricks** | Storage credential, external location, catalog, marketing notebook | Same |
+
+> [!NOTE]
+> **Azure and AI sentiment**
+>
+> Azure demo does not create `reviews_with_sentiment` or the Databricks `hotel_performance` view. See the [Confluent Cloud release notes](https://docs.confluent.io/cloud/current/release-notes/index.html#march-19-2026).
 
 ### Prerequisites
 
@@ -27,7 +32,7 @@ Complete **[LAB 1: Account Setup](../LAB1_account_setup/LAB1.md)** with all cred
 
 ### Step 1: Initialize and Apply Terraform
 
-1. Open your terminal in the `terraform/aws-demo` directory
+1. Open your terminal in the demo directory from LAB 0 (`terraform/aws-demo` or `terraform/azure-demo`)
 2. Initialize Terraform:
 
    ```sh
@@ -43,10 +48,10 @@ Complete **[LAB 1: Account Setup](../LAB1_account_setup/LAB1.md)** with all cred
 > [!NOTE]
 > **Expected Duration**
 >
-> The full apply takes approximately 15-25 minutes. The longest steps are:
-> - EC2 instance provisioning and data generator startup (~5 min)
+> The full apply takes approximately 15-25 minutes. The longest steps are typically:
+> - Cloud database / data generator startup (~5 min; EC2 on AWS, Flexible Server on Azure)
 > - CDC connector creation and initial snapshot (~3 min)
-> - IAM trust policy propagation (2x sleep: 60s + 30s)
+> - Cloud IAM / RBAC propagation sleeps
 > - Flink Materialized Table creation (~2 min)
 > - Wait for Materialized Table topic creation (120s sleep)
 > - Tableflow topic enablement (~1 min)
@@ -84,7 +89,7 @@ Now explore what Terraform created in the Confluent Cloud UI:
    - `riverhotel.cdc.customer` and `riverhotel.cdc.hotel` (CDC from PostgreSQL)
    - `clickstream`, `bookings`, `reviews` (direct from data generator)
    - `denormalized_hotel_bookings` (created by Flink Materialized Table)
-   - `reviews_with_sentiment` (created by Flink Materialized Table)
+   - `reviews_with_sentiment` (AWS only — Flink Materialized Table with `AI_SENTIMENT`)
 
 #### CDC Connector
 
@@ -100,16 +105,16 @@ Now explore what Terraform created in the Confluent Cloud UI:
 #### Tableflow
 
 1. Click on **Tableflow** in the left menu
-2. Verify you see three Tableflow-enabled topics:
+2. Verify Tableflow-enabled topics:
    - `clickstream` (syncing)
    - `denormalized_hotel_bookings` (syncing)
-   - `reviews_with_sentiment` (syncing)
+   - `reviews_with_sentiment` (syncing — **AWS only**)
 3. Under **External Catalog Integrations**, verify the Unity Catalog integration shows **Connected** (or **Pending** if sync hasn't completed yet)
 
 > [!IMPORTANT]
 > **Tableflow Sync Startup Time**
 >
-> It takes 10-15 minutes for Tableflow to fully sync data to S3 and register tables in Unity Catalog. The `clickstream` topic (high throughput) typically syncs first. The Materialized Table topics may take a few extra minutes since they need data from the continuous Flink queries.
+> It takes 10-15 minutes for Tableflow to fully sync data to object storage (S3 or ADLS Gen2) and register tables in Unity Catalog. The `clickstream` topic (high throughput) typically syncs first. The Materialized Table topics may take a few extra minutes since they need data from the continuous Flink queries.
 >
 > You can proceed to explore Confluent Cloud while waiting, but you will need the sync to complete before LAB 3.
 
@@ -122,7 +127,7 @@ Here is a summary of what demo mode automated compared to self-service:
 | **Unity Catalog Integration** | Manual wizard in CC UI (LAB3) | `confluent_catalog_integration` Terraform resource |
 | **Tableflow on clickstream** | Manual enable in CC UI (LAB3) | `confluent_tableflow_topic` Terraform resource |
 | **denormalized_hotel_bookings** | Manual Flink Materialized Table SQL (LAB4) | `confluent_flink_materialized_table` Terraform resource |
-| **reviews_with_sentiment** | Manual Flink Materialized Table SQL (LAB4) | `confluent_flink_materialized_table` Terraform resource |
+| **reviews_with_sentiment** | Manual Flink Materialized Table SQL (LAB4) | Automated on **AWS**; skipped on **Azure** (`AI_SENTIMENT` AWS-only) |
 | **Tableflow on Materialized Table topics** | Manual enable in CC UI (LAB4) | `confluent_tableflow_topic` Terraform resource |
 | **Notebook import** | Manual import from URL (LAB5) | `databricks_notebook` Terraform resource |
 
@@ -131,9 +136,9 @@ Here is a summary of what demo mode automated compared to self-service:
 
 **`denormalized_hotel_bookings`** uses temporal joins to combine streaming bookings with point-in-time lookups against customer and hotel dimension tables. The `FOR SYSTEM_TIME AS OF` clause retrieves the dimension record as it existed at the time of each booking event.
 
-**`reviews_with_sentiment`** enriches hotel reviews with aspect-based sentiment analysis using Confluent's built-in `AI_SENTIMENT` function. It evaluates each review across three aspects (cleanliness, amenities, service) and flattens the scores into individual columns for clean downstream analytics.
+**`reviews_with_sentiment`** (AWS only) enriches hotel reviews with aspect-based sentiment analysis using Confluent's built-in `AI_SENTIMENT` function. It evaluates each review across three aspects (cleanliness, amenities, service) and flattens the scores into individual columns for clean downstream analytics.
 
-Both materialized tables run continuous queries as persistent Flink jobs.
+Materialized tables run continuous queries as persistent Flink jobs.
 
 </details>
 
@@ -142,7 +147,7 @@ Both materialized tables run continuous queries as persistent Flink jobs.
 
 When Tableflow is enabled on a topic, Confluent starts two jobs:
 
-1. **Materializer Job**: Reads from Kafka (via tiered storage for performance), converts data to Parquet format, and writes to your S3 bucket
+1. **Materializer Job**: Reads from Kafka (via tiered storage for performance), converts data to Parquet format, and writes to your object store (S3 or ADLS Gen2)
 2. **Committer Job**: Commits snapshots to Delta Lake with exactly-once semantics and syncs metadata to Unity Catalog
 
 The result is that Kafka topics appear as queryable Delta Lake tables in Databricks.
@@ -151,9 +156,9 @@ The result is that Kafka topics appear as queryable Delta Lake tables in Databri
 
 ## Conclusion
 
-Your entire real-time AI marketing pipeline is now running. Data flows from PostgreSQL through CDC to Kafka, gets enriched by Flink with temporal joins and AI sentiment analysis, and is materialized as Delta Lake tables via Tableflow.
+Your entire real-time AI marketing pipeline is now running. Data flows from PostgreSQL through CDC to Kafka, gets enriched by Flink (temporal joins, and on AWS AI sentiment analysis), and is materialized as Delta Lake tables via Tableflow.
 
-> **Data Quality Rules**: Terraform also deployed a CEL-based data quality rule on the clickstream schema with a Dead Letter Queue. To explore this, see the optional **[Data Governance Lab](../LAB_data_governance/LAB_data_governance.md)** — you can demonstrate live DQR enforcement via `curl localhost:9400/test-dqr` on the EC2 instance.
+> **Data Quality Rules**: Terraform also deployed a CEL-based data quality rule on the clickstream schema with a Dead Letter Queue. To explore this, see the optional **[Data Governance Lab](../LAB_data_governance/LAB_data_governance.md)**. On **AWS**, you can demonstrate live DQR enforcement via `curl localhost:9400/test-dqr` on the EC2 instance.
 
 ## What's Next
 

--- a/labs/demo/LAB3_analytics_ai/LAB3.md
+++ b/labs/demo/LAB3_analytics_ai/LAB3.md
@@ -8,13 +8,16 @@ Your streaming pipeline is fully operational -- data is flowing from PostgreSQL 
 
 By the end of this lab, you will have:
 
-1. **Explored Hotel Performance Analytics**: Verified Tableflow tables in Unity Catalog and queried the `hotel_performance` view for sentiment-ranked hotel insights
-2. **AI-Powered Business Intelligence**: Used Databricks Genie to generate natural language insights about sentiment and performance
+1. **Explored Hotel Performance Analytics**: Verified Tableflow tables in Unity Catalog and queried analytics (on AWS: `hotel_performance` / sentiment; on Azure: `clickstream` and `denormalized_hotel_bookings`)
+2. **AI-Powered Business Intelligence**: Used Databricks Genie to generate natural language insights
 3. **Intelligent Marketing Automation**: Configured and ran a pre-imported AI agent notebook that identifies underperforming hotels and generates targeted marketing campaigns
 
 ### Prerequisites
 
 Completed **[LAB 2: Deploy and Observe](../LAB2_deploy_and_observe/LAB2.md)** with Tableflow sync complete (tables visible in Unity Catalog).
+
+> [!WARNING]
+> **Azure attendees:** several sections of this lab depend on the `reviews_with_sentiment` Delta table and the `hotel_performance` view, which are not created in `azure-demo` because `AI_SENTIMENT` is not yet available in Confluent Cloud Azure regions. Read through the sentiment steps for context, but expect to skip execution. Genie and the marketing-agent notebook still demonstrate value using `denormalized_hotel_bookings` and `clickstream`. Track availability in the [Confluent Cloud Flink AI release notes](https://docs.confluent.io/cloud/current/release-notes/index.html).
 
 ## Steps
 
@@ -24,14 +27,19 @@ Completed **[LAB 2: Deploy and Observe](../LAB2_deploy_and_observe/LAB2.md)** wi
 2. Click on **Catalog** in the left menu
 3. Expand your Tableflow catalog (name from `terraform output databricks_integration`)
 4. Expand the Confluent cluster schema (matches your Kafka cluster ID)
-5. Verify you see three Tableflow tables: `clickstream`, `denormalized_hotel_bookings`, and `reviews_with_sentiment`
+5. Verify Tableflow tables:
+   - **AWS**: `clickstream`, `denormalized_hotel_bookings`, and `reviews_with_sentiment`
+   - **Azure**: `clickstream` and `denormalized_hotel_bookings`
 
 > [!IMPORTANT]
 > **Tableflow Sync Time**
 >
-> If you do not see all three tables, Tableflow may still be syncing. Check the Tableflow status in Confluent Cloud. The `clickstream` table typically appears first (high throughput), followed by the Materialized Table topics.
+> If you do not see the expected tables, Tableflow may still be syncing. Check the Tableflow status in Confluent Cloud. The `clickstream` table typically appears first (high throughput), followed by the Materialized Table topics.
 
-The `hotel_performance` SQL view was pre-created by Terraform. It aggregates booking metrics and sentiment analysis scores from `denormalized_hotel_bookings` and `reviews_with_sentiment`.
+On **AWS**, the `hotel_performance` SQL view was pre-created by Terraform. It aggregates booking metrics and sentiment analysis scores from `denormalized_hotel_bookings` and `reviews_with_sentiment`.
+
+> [!NOTE]
+> **Azure attendees: skip the `hotel_performance` query below.** Continue to Genie using `clickstream` and `denormalized_hotel_bookings`.
 
 6. Click the **Create** dropdown and select **Query**
 7. Select your catalog and schema from the dropdowns
@@ -63,7 +71,9 @@ Databricks Genie provides a chat interface where you ask questions about your da
 1. Click on **Genie** under the *SQL* section in the left sidebar
 2. Click **+ New** to create a new Genie space
 3. Click **All** and navigate to your workshop catalog and database
-4. Select the `clickstream`, `denormalized_hotel_bookings`, `reviews_with_sentiment`, and `hotel_performance` tables
+4. Select tables for your cloud:
+   - **AWS**: `clickstream`, `denormalized_hotel_bookings`, `reviews_with_sentiment`, and `hotel_performance`
+   - **Azure**: `clickstream` and `denormalized_hotel_bookings`
 5. Click **Create**
 6. Rename your space to something like *River Hotel BI*
 
@@ -73,7 +83,9 @@ Toggle the **Agent** mode and try prompts like:
 
 > Show me customer satisfaction metrics by country
 
-> Which hotels have the highest positive sentiment across cleanliness, amenities, and service?
+> Which hotels have the highest booking volume by city? *(Azure-friendly)*
+
+> Which hotels have the highest positive sentiment across cleanliness, amenities, and service? *(AWS — requires `reviews_with_sentiment`)*
 
 > Which category of hotel had the lowest interest from customers?
 

--- a/labs/demo/LAB4_cleanup/LAB4.md
+++ b/labs/demo/LAB4_cleanup/LAB4.md
@@ -38,13 +38,15 @@ docker-compose run --rm terraform -c "terraform destroy -auto-approve"
 ```
 
 Terraform will destroy resources in the correct order:
-1. Tableflow topic enablement (disables Tableflow on all three topics)
+1. Tableflow topic enablement
 2. Flink Materialized Tables (stops the running Flink queries)
 3. Unity Catalog integration
 4. Databricks notebook, catalog, external location, storage credential
 5. CDC connector, Flink statements, Flink compute pool
 6. Confluent environment and cluster
-7. AWS resources (EC2, S3, VPC, IAM)
+7. Cloud resources:
+   - **AWS**: EC2, S3, VPC, IAM
+   - **Azure**: Flexible Server, ADLS Gen2, Resource Group, related RBAC
 
 > [!NOTE]
 > **Expected Duration**
@@ -55,7 +57,7 @@ Terraform will destroy resources in the correct order:
 
 Verify resources are removed from:
 
-- **AWS Console**: EC2 instances, S3 buckets, IAM roles
+- **Cloud console**: AWS (EC2, S3, IAM) or Azure (Resource Group, storage, PostgreSQL)
 - **Confluent Cloud**: Environments, clusters, compute pools
 - **Databricks**: External locations, storage credentials, catalogs
 

--- a/labs/demo/LAB_data_governance/LAB_data_governance.md
+++ b/labs/demo/LAB_data_governance/LAB_data_governance.md
@@ -2,15 +2,20 @@
 
 ## Overview
 
-Your demo environment (`aws-demo`) was deployed with a pre-configured data quality rule on the clickstream topic. This lab walks through observing the rule, demonstrating live enforcement via the `/test-dqr` endpoint, and exploring governance features.
+Your demo environment was deployed with a pre-configured data quality rule on the clickstream topic. This lab walks through observing the rule, demonstrating live enforcement (on **AWS** via the `/test-dqr` endpoint on EC2), and exploring governance features.
 
 Since demo mode is fully automated by Terraform, all rules and the DLQ topic are already deployed — this lab is observation and demonstration only.
 
 ### What You'll Explore
 
 - **Pre-deployed DQR**: A CEL rule validating the `action` field on the clickstream schema
-- **Live DQR Demo**: Trigger rule enforcement via the data generator's `/test-dqr` HTTP endpoint
+- **Live DQR Demo** (AWS): Trigger rule enforcement via the data generator's `/test-dqr` HTTP endpoint on the EC2 instance
 - **DLQ Observation**: See invalid events routed to the `invalid_clickstream_events` topic
+
+> [!NOTE]
+> **Azure**
+>
+> Schema Registry rules and the DLQ topic are still provisioned on Azure. The interactive `/test-dqr` curl demo below is AWS-specific (EC2-hosted data generator). On Azure, observe the rule in Schema Registry and invalid events that the generator routes to the DLQ during normal streaming (~5% invalid actions).
 
 ### Prerequisites
 
@@ -35,7 +40,9 @@ The **On failure** action is `DLQ`, routing invalid events to `invalid_clickstre
 
 **What Terraform Deployed:** The `data_contracts` module registered this schema with the CEL rule and created the DLQ topic. This happened automatically during `terraform apply`, before the CDC connector and data generator started.
 
-### Step 2: Demonstrate Live DQR Enforcement
+### Step 2: Demonstrate Live DQR Enforcement (AWS)
+
+> Skip this step on Azure — continue to Step 3 and inspect DLQ messages from normal streaming traffic.
 
 SSH to the EC2 instance running the data generator and trigger the test endpoint:
 

--- a/terraform/aws-demo/datagen.tf
+++ b/terraform/aws-demo/datagen.tf
@@ -24,7 +24,7 @@ variable "datagen_ssh_username" {
 }
 
 locals {
-  deploy_datagen = var.enable_datagen
+  deploy_datagen = var.enable_datagen && !local.use_shared
   data_dir       = "${path.module}/../../data"
 }
 
@@ -62,17 +62,17 @@ resource "local_file" "datagen_confluent_connection" {
     kind     = "kafka"
     logLevel = "ERROR"
     producerConfigs = {
-      "bootstrap.servers"              = module.confluent_platform.bootstrap_endpoint_url
-      "schema.registry.url"            = module.confluent_platform.schema_registry_endpoint
-      "basic.auth.user.info"           = "${module.confluent_platform.schema_registry_api_key}:${module.confluent_platform.schema_registry_api_secret}"
-      "basic.auth.credentials.source"  = "USER_INFO"
-      "key.serializer"                 = "org.apache.kafka.common.serialization.StringSerializer"
-      "value.serializer"               = "io.confluent.kafka.serializers.KafkaAvroSerializer"
-      "sasl.jaas.config"               = "org.apache.kafka.common.security.plain.PlainLoginModule required username='${module.confluent_platform.kafka_api_key}' password='${module.confluent_platform.kafka_api_secret}';"
-      "sasl.mechanism"                 = "PLAIN"
-      "security.protocol"              = "SASL_SSL"
-      "auto.register.schemas"          = "false"
-      "use.latest.version"             = "true"
+      "bootstrap.servers"             = module.confluent_platform.bootstrap_endpoint_url
+      "schema.registry.url"           = module.confluent_platform.schema_registry_endpoint
+      "basic.auth.user.info"          = "${module.confluent_platform.schema_registry_api_key}:${module.confluent_platform.schema_registry_api_secret}"
+      "basic.auth.credentials.source" = "USER_INFO"
+      "key.serializer"                = "org.apache.kafka.common.serialization.StringSerializer"
+      "value.serializer"              = "io.confluent.kafka.serializers.KafkaAvroSerializer"
+      "sasl.jaas.config"              = "org.apache.kafka.common.security.plain.PlainLoginModule required username='${module.confluent_platform.kafka_api_key}' password='${module.confluent_platform.kafka_api_secret}';"
+      "sasl.mechanism"                = "PLAIN"
+      "security.protocol"             = "SASL_SSL"
+      "auto.register.schemas"         = "false"
+      "use.latest.version"            = "true"
     }
   })
 
@@ -88,7 +88,7 @@ resource "null_resource" "datagen_setup" {
   count = local.deploy_datagen ? 1 : 0
 
   triggers = {
-    instance_id    = module.postgres.instance_id
+    instance_id    = module.postgres[0].instance_id
     pg_config_hash = md5(local_file.datagen_postgres_connection[0].content)
     cc_config_hash = md5(local_file.datagen_confluent_connection[0].content)
   }
@@ -103,9 +103,9 @@ resource "null_resource" "datagen_setup" {
 
   connection {
     type        = "ssh"
-    host        = module.postgres.public_dns
+    host        = module.postgres[0].public_dns
     user        = var.datagen_ssh_username
-    private_key = file(module.keypair.private_key_path)
+    private_key = file(module.keypair[0].private_key_path)
     timeout     = "10m"
   }
 
@@ -333,5 +333,5 @@ output "datagen_enabled" {
 
 output "datagen_ssh_command" {
   description = "SSH command to check Data Generator logs"
-  value       = local.deploy_datagen ? "ssh -i ${module.keypair.private_key_path} ${var.datagen_ssh_username}@${module.postgres.public_dns} 'docker logs -f datagen'" : ""
+  value       = local.deploy_datagen ? "ssh -i ${module.keypair[0].private_key_path} ${var.datagen_ssh_username}@${module.postgres[0].public_dns} 'docker logs -f datagen'" : ""
 }

--- a/terraform/aws-demo/main.tf
+++ b/terraform/aws-demo/main.tf
@@ -8,6 +8,11 @@
 #   - Tableflow topic enablement (clickstream, denormalized_hotel_bookings, reviews_with_sentiment)
 #   - Databricks notebook import (marketing agent)
 #
+# Supports two modes:
+#   Self-service: all resources created per-account (shared_* vars empty)
+#   WSA mode:     shared infra provided via shared_* vars (networking, S3,
+#                 keypair, and PostgreSQL modules are skipped)
+#
 # Users run `terraform apply` once and get the entire pipeline.
 
 # ===============================
@@ -25,7 +30,49 @@ resource "random_id" "env_display_id" {
 locals {
   prefix          = "${var.prefix}-${var.project_name}"
   resource_suffix = random_id.env_display_id.hex
-  effective_email = var.confluent_cloud_email
+
+  # WSA: use per-account email when provided, fall back to self-service email
+  effective_email = var.account_email != "" ? var.account_email : var.confluent_cloud_email
+
+  # When shared_* vars are set, use them; otherwise use per-account module outputs.
+  use_shared = var.shared_vpc_id != ""
+
+  effective_vpc_id                     = local.use_shared ? var.shared_vpc_id : module.networking[0].vpc_id
+  effective_subnet_id                  = local.use_shared ? var.shared_subnet_id : module.networking[0].public_subnet_id
+  effective_aws_account                = local.use_shared ? data.aws_caller_identity.current[0].account_id : module.networking[0].aws_account_id
+  effective_s3_bucket_name             = local.use_shared ? var.shared_s3_bucket_name : module.s3[0].bucket_name
+  effective_s3_bucket_arn              = local.use_shared ? var.shared_s3_bucket_arn : module.s3[0].bucket_arn
+  effective_s3_bucket_url              = local.use_shared ? var.shared_s3_bucket_url : module.s3[0].bucket_url
+  effective_key_name                   = local.use_shared ? var.shared_key_name : module.keypair[0].key_name
+  effective_postgres_dns               = local.use_shared ? var.shared_postgres_hostname : module.postgres[0].public_dns
+  effective_postgres_ip                = local.use_shared ? var.shared_postgres_public_ip : module.postgres[0].public_ip
+  effective_postgres_db_password       = local.use_shared && var.shared_postgres_db_password != "" ? var.shared_postgres_db_password : var.postgres_db_password
+  effective_postgres_debezium_password = local.use_shared && var.shared_postgres_debezium_password != "" ? var.shared_postgres_debezium_password : var.postgres_debezium_password
+
+  common_tags = merge(
+    {
+      Project     = "Hospitality AI Agent"
+      Environment = var.environment
+      Created_by  = "Terraform"
+      owner_email = local.effective_email
+      mode        = "demo"
+    },
+    var.aws_account_tag != "" ? { workshop_account = var.aws_account_tag } : {}
+  )
+
+  iam_role_name = "${local.prefix}-unified-role-${local.resource_suffix}"
+
+  # Topic names: WSA/shared uses CDC-prefixed topics; standalone demo uses plain names
+  clickstream_topic = local.use_shared ? "riverhotel.cdc.clickstream" : "clickstream"
+  bookings_topic    = local.use_shared ? "riverhotel.cdc.bookings" : "bookings"
+  reviews_topic     = local.use_shared ? "riverhotel.cdc.reviews" : "reviews"
+  customer_topic    = "riverhotel.cdc.customer"
+  hotel_topic       = "riverhotel.cdc.hotel"
+}
+
+# AWS account ID lookup (only needed in shared mode where networking module is skipped)
+data "aws_caller_identity" "current" {
+  count = local.use_shared ? 1 : 0
 }
 
 # ===============================
@@ -33,6 +80,7 @@ locals {
 # ===============================
 
 module "networking" {
+  count  = local.use_shared ? 0 : 1
   source = "../aws/modules/aws-networking"
 
   prefix      = local.prefix
@@ -44,6 +92,7 @@ module "networking" {
 # ===============================
 
 module "keypair" {
+  count  = local.use_shared ? 0 : 1
   source = "../aws/modules/aws-keypair"
 
   prefix          = local.prefix
@@ -57,27 +106,12 @@ module "keypair" {
 # ===============================
 
 module "s3" {
+  count  = local.use_shared ? 0 : 1
   source = "../aws/modules/aws-s3"
 
   prefix          = local.prefix
   resource_suffix = local.resource_suffix
   common_tags     = local.common_tags
-}
-
-# ===============================
-# Common Tags
-# ===============================
-
-locals {
-  common_tags = {
-    Project     = "Hospitality AI Agent"
-    Environment = var.environment
-    Created_by  = "Terraform"
-    owner_email = local.effective_email
-    mode        = "demo"
-  }
-
-  iam_role_name = "${local.prefix}-unified-role-${local.resource_suffix}"
 }
 
 # ===============================
@@ -107,7 +141,7 @@ module "tableflow" {
   environment_id  = module.confluent_platform.environment_id
   cloud_provider  = "aws"
 
-  customer_iam_role_arn = "arn:aws:iam::${module.networking.aws_account_id}:role/${local.iam_role_name}"
+  customer_iam_role_arn = "arn:aws:iam::${local.effective_aws_account}:role/${local.iam_role_name}"
 
   depends_on = [module.confluent_platform]
 }
@@ -136,18 +170,19 @@ module "flink" {
 # ===============================
 
 module "postgres" {
+  count  = local.use_shared ? 0 : 1
   source = "../aws/modules/aws-postgres"
 
   prefix              = local.prefix
-  vpc_id              = module.networking.vpc_id
-  subnet_id           = module.networking.public_subnet_id
-  key_name            = module.keypair.key_name
+  vpc_id              = local.effective_vpc_id
+  subnet_id           = local.effective_subnet_id
+  key_name            = local.effective_key_name
   instance_type       = var.postgres_instance_type
   allowed_cidr_blocks = var.allowed_cidr_blocks
   db_name             = var.postgres_db_name
   db_username         = var.postgres_db_username
-  db_password         = var.postgres_db_password
-  debezium_password   = var.postgres_debezium_password
+  db_password         = local.effective_postgres_db_password
+  debezium_password   = local.effective_postgres_debezium_password
   common_tags         = local.common_tags
 
   depends_on = [module.networking, module.keypair]
@@ -162,9 +197,9 @@ module "iam" {
 
   prefix                                    = local.prefix
   resource_suffix                           = local.resource_suffix
-  aws_account_id                            = module.networking.aws_account_id
-  s3_bucket_arn                             = module.s3.bucket_arn
-  s3_bucket_id                              = module.s3.bucket_name
+  aws_account_id                            = local.effective_aws_account
+  s3_bucket_arn                             = local.effective_s3_bucket_arn
+  s3_bucket_id                              = local.effective_s3_bucket_name
   confluent_iam_role_arn                    = module.tableflow.iam_role_arn
   confluent_external_id                     = module.tableflow.external_id
   databricks_account_id                     = var.databricks_account_id
@@ -189,20 +224,27 @@ module "databricks" {
   resource_suffix             = local.resource_suffix
   cloud_provider              = "aws"
   iam_role_arn                = module.iam.role_arn
-  s3_bucket_url               = module.s3.bucket_url
+  s3_bucket_url               = local.effective_s3_bucket_url
   user_email                  = var.databricks_user_email
-  sso_email                   = ""
+  sso_email                   = var.databricks_sso_email
   service_principal_client_id = var.databricks_service_principal_client_id
   kafka_cluster_id            = module.confluent_platform.kafka_cluster_id
+  sql_warehouse_name          = var.databricks_sql_warehouse_name
+
+  # WSA mode (shared infra): create users via SCIM and skip admins membership.
+  lookup_existing_users = !local.use_shared
+  add_user_to_admins    = !local.use_shared
 
   depends_on = [module.iam, module.s3, module.tableflow]
 }
 
 # ===============================
-# AWS IAM Trust Policy Update - PHASE 1
+# AWS IAM Trust Policy Update - PHASE 1 (self-service only)
 # ===============================
 
 resource "null_resource" "update_iam_trust_policy_phase1" {
+  count = local.use_shared ? 0 : 1
+
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
@@ -229,7 +271,7 @@ resource "null_resource" "update_iam_trust_policy_phase1" {
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "AWS": "arn:aws:iam::${module.networking.aws_account_id}:root"
+                "AWS": "arn:aws:iam::${local.effective_aws_account}:root"
               }
             }
           ]
@@ -251,6 +293,8 @@ resource "null_resource" "update_iam_trust_policy_phase1" {
 # ===============================
 
 resource "null_resource" "wait_for_trust_policy_phase1" {
+  count = local.use_shared ? 0 : 1
+
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
@@ -268,6 +312,8 @@ resource "null_resource" "wait_for_trust_policy_phase1" {
 # ===============================
 
 resource "null_resource" "update_iam_trust_policy_phase2" {
+  count = local.use_shared ? 0 : 1
+
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
@@ -340,6 +386,8 @@ resource "null_resource" "update_iam_trust_policy_phase2" {
 # ===============================
 
 resource "null_resource" "wait_for_trust_policy_phase2" {
+  count = local.use_shared ? 0 : 1
+
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
@@ -357,10 +405,11 @@ resource "null_resource" "wait_for_trust_policy_phase2" {
 # ===============================
 
 resource "databricks_external_location" "main" {
+  count    = local.use_shared ? 0 : 1
   provider = databricks.workspace
 
   name            = "${local.prefix}-external-location-${local.resource_suffix}"
-  url             = module.s3.bucket_url
+  url             = local.effective_s3_bucket_url
   credential_name = module.databricks.storage_credential_name
   comment         = "External location for Unity Catalog and Tableflow S3 access"
   force_destroy   = true
@@ -374,9 +423,10 @@ resource "databricks_external_location" "main" {
 # ===============================
 
 resource "databricks_grants" "external_location" {
+  count    = local.use_shared ? 0 : 1
   provider = databricks.workspace
 
-  external_location = databricks_external_location.main.name
+  external_location = databricks_external_location.main[0].name
 
   grant {
     principal = var.databricks_user_email
@@ -418,7 +468,7 @@ resource "databricks_catalog" "main" {
 
   name          = "${local.prefix}-${local.resource_suffix}"
   comment       = "Dedicated catalog for Confluent Tableflow integration"
-  storage_root  = "${module.s3.bucket_url}${local.prefix}/catalog/"
+  storage_root  = "${local.effective_s3_bucket_url}${local.prefix}/catalog/"
   force_destroy = true
 
   depends_on = [module.databricks, databricks_external_location.main]
@@ -456,18 +506,33 @@ resource "databricks_grants" "catalog" {
     ]
   }
 
+  dynamic "grant" {
+    for_each = var.databricks_sso_email != "" ? [var.databricks_sso_email] : []
+    content {
+      principal = grant.value
+      privileges = [
+        "ALL_PRIVILEGES",
+        "USE_CATALOG",
+        "CREATE_SCHEMA",
+        "USE_SCHEMA",
+        "EXTERNAL_USE_SCHEMA"
+      ]
+    }
+  }
+
   depends_on = [databricks_catalog.main]
 }
 
 # ===============================
 # Data Quality Rules (Data Contracts)
 # ===============================
-# Pre-registers all schemas with CEL rules and creates DLQ topic.
-# Demo path uses self-service generators (direct Kafka), so needs
-# all schemas registered and no topic prefix.
+# Demo standalone path registers all schemas with no topic prefix.
+# Skip in WSA/shared mode to avoid CDC schema subject collisions.
 
 module "data_contracts" {
   source = "../modules/confluent-data-contracts"
+
+  count = local.use_shared ? 0 : 1
 
   environment_id             = module.confluent_platform.environment_id
   kafka_cluster_id           = module.confluent_platform.kafka_cluster_id
@@ -496,14 +561,14 @@ module "connectors" {
   environment_id       = module.confluent_platform.environment_id
   kafka_cluster_id     = module.confluent_platform.kafka_cluster_id
   service_account_id   = module.confluent_platform.service_account_id
-  postgres_hostname    = module.postgres.public_dns
+  postgres_hostname    = local.effective_postgres_dns
   postgres_port        = var.postgres_db_port
   database_name        = var.postgres_db_name
   debezium_username    = var.postgres_debezium_username
-  debezium_password    = var.postgres_debezium_password
+  debezium_password    = local.effective_postgres_debezium_password
   table_include_list   = var.table_include_list
-  ssh_key_path         = module.keypair.private_key_path
-  initial_wait_seconds = 90
+  ssh_key_path         = local.use_shared ? "" : module.keypair[0].private_key_path
+  initial_wait_seconds = local.use_shared ? 0 : 90
 
   depends_on = [module.postgres, module.confluent_platform, module.keypair, module.data_contracts, null_resource.datagen_setup]
 }
@@ -525,9 +590,9 @@ module "flink_statements" {
   flink_api_secret           = module.flink.flink_api_secret
   flink_rest_endpoint        = module.flink.flink_rest_endpoint
 
-  clickstream_topic = "clickstream"
-  bookings_topic    = "bookings"
-  reviews_topic     = "reviews"
+  clickstream_topic = local.clickstream_topic
+  bookings_topic    = local.bookings_topic
+  reviews_topic     = local.reviews_topic
 
   depends_on = [module.connectors, module.flink]
 }
@@ -537,13 +602,14 @@ module "flink_statements" {
 # ===============================
 
 module "data_generator" {
+  count  = local.use_shared ? 0 : 1
   source = "../modules/data-generator"
 
   output_path                = "../../data/connections"
-  postgres_hostname          = module.postgres.public_ip
+  postgres_hostname          = local.effective_postgres_ip
   postgres_port              = var.postgres_db_port
   postgres_username          = var.postgres_db_username
-  postgres_password          = var.postgres_db_password
+  postgres_password          = local.effective_postgres_db_password
   postgres_database          = var.postgres_db_name
   kafka_bootstrap_endpoint   = module.confluent_platform.bootstrap_endpoint_url
   kafka_api_key              = module.confluent_platform.kafka_api_key
@@ -598,9 +664,9 @@ resource "confluent_api_key" "tableflow" {
 module "catalog_integration" {
   source = "../modules/confluent-catalog-integration"
 
-  prefix          = local.prefix
-  resource_suffix = local.resource_suffix
-  environment_id  = module.confluent_platform.environment_id
+  prefix           = local.prefix
+  resource_suffix  = local.resource_suffix
+  environment_id   = module.confluent_platform.environment_id
   kafka_cluster_id = module.confluent_platform.kafka_cluster_id
 
   databricks_workspace_url    = var.databricks_host
@@ -629,19 +695,24 @@ module "catalog_integration" {
 module "flink_ctas" {
   source = "../modules/confluent-flink-ctas"
 
-  organization_id    = module.confluent_platform.organization_id
-  environment_id     = module.confluent_platform.environment_id
-  kafka_cluster_id   = module.confluent_platform.kafka_cluster_id
-  compute_pool_id    = module.flink.compute_pool_id
-  service_account_id = module.confluent_platform.service_account_id
-  flink_api_key      = module.flink.flink_api_key
-  flink_api_secret   = module.flink.flink_api_secret
-  flink_rest_endpoint = module.flink.flink_rest_endpoint
+  organization_id            = module.confluent_platform.organization_id
+  environment_id             = module.confluent_platform.environment_id
+  environment_name           = module.confluent_platform.environment_name
+  kafka_cluster_id           = module.confluent_platform.kafka_cluster_id
+  kafka_cluster_display_name = module.confluent_platform.kafka_cluster_display_name
+  compute_pool_id            = module.flink.compute_pool_id
+  service_account_id         = module.confluent_platform.service_account_id
+  flink_api_key              = module.flink.flink_api_key
+  flink_api_secret           = module.flink.flink_api_secret
+  flink_rest_endpoint        = module.flink.flink_rest_endpoint
 
-  bookings_topic = "bookings"
-  reviews_topic  = "reviews"
+  bookings_topic = local.bookings_topic
+  reviews_topic  = local.reviews_topic
+  customer_topic = local.customer_topic
+  hotel_topic    = local.hotel_topic
 
-  depends_on = [module.flink_statements]
+  # flink_statements configures changelog/watermark; connectors ensure CDC topics exist
+  depends_on = [module.flink_statements, module.connectors]
 }
 
 # ===============================
@@ -656,9 +727,10 @@ module "tableflow_topics" {
 
   environment_id          = module.confluent_platform.environment_id
   kafka_cluster_id        = module.confluent_platform.kafka_cluster_id
-  s3_bucket_name          = module.s3.bucket_name
+  cloud_provider          = "aws"
+  s3_bucket_name          = local.effective_s3_bucket_name
   provider_integration_id = module.tableflow.integration_id
-  clickstream_topic       = "clickstream"
+  clickstream_topic       = local.clickstream_topic
 
   api_key    = confluent_api_key.tableflow.id
   api_secret = confluent_api_key.tableflow.secret

--- a/terraform/aws-demo/variables.tf
+++ b/terraform/aws-demo/variables.tf
@@ -184,6 +184,12 @@ variable "databricks_service_principal_client_secret" {
   }
 }
 
+variable "databricks_sql_warehouse_name" {
+  description = "Name of the Databricks SQL warehouse to look up (must already exist in the workspace)"
+  type        = string
+  default     = "Serverless Starter Warehouse"
+}
+
 variable "allowed_cidr_blocks" {
   description = "List of CIDR blocks allowed to access PostgreSQL and SSH"
   type        = list(string)
@@ -194,4 +200,135 @@ variable "table_include_list" {
   description = "Comma-separated PostgreSQL tables for CDC"
   type        = string
   default     = "cdc.customer,cdc.hotel"
+}
+
+# ---------------------
+# WSA integration variables (defaults preserve backward compatibility for self-service)
+# ---------------------
+
+variable "account_email" {
+  description = "WSA: per-account email (overrides var.confluent_cloud_email when set)"
+  type        = string
+  default     = ""
+}
+
+variable "account_number" {
+  description = "WSA: account number for this run"
+  type        = number
+  default     = 0
+}
+
+variable "cc_environment_name" {
+  description = "WSA: pre-created Confluent Cloud environment name"
+  type        = string
+  default     = ""
+}
+
+variable "dbx_workspace_url" {
+  description = "WSA: Databricks workspace URL for CSV output"
+  type        = string
+  default     = ""
+}
+
+variable "dbx_schema_name" {
+  description = "WSA: Databricks schema name (per-user isolation)"
+  type        = string
+  default     = ""
+}
+
+variable "dbx_catalog_name" {
+  description = "WSA: Databricks catalog name (per-user isolation)"
+  type        = string
+  default     = ""
+}
+
+variable "databricks_sso_email" {
+  description = "WSA: Azure AD UPN for the participant (e.g., wp2@tenant.onmicrosoft.com). When set, catalog and storage credential grants are added for this identity in addition to databricks_user_email."
+  type        = string
+  default     = ""
+}
+
+variable "aws_account_tag" {
+  description = "WSA: tag value for per-account resource identification"
+  type        = string
+  default     = ""
+}
+
+# ---------------------
+# Shared infrastructure variables (set by wsa when using terraform/aws-shared/)
+# ---------------------
+
+variable "shared_vpc_id" {
+  description = "WSA: shared VPC ID (skips networking module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_subnet_id" {
+  description = "WSA: shared subnet ID (skips networking module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_s3_bucket_name" {
+  description = "WSA: shared S3 bucket name (skips S3 module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_s3_bucket_arn" {
+  description = "WSA: shared S3 bucket ARN (skips S3 module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_s3_bucket_url" {
+  description = "WSA: shared S3 bucket URL (skips S3 module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_key_name" {
+  description = "WSA: shared SSH key name (skips keypair module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_postgres_hostname" {
+  description = "WSA: shared PostgreSQL hostname (skips postgres module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_postgres_public_ip" {
+  description = "WSA: shared PostgreSQL public IP (skips postgres module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_postgres_db_password" {
+  description = "WSA: shared PostgreSQL admin password (from shared infra output)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "shared_postgres_debezium_password" {
+  description = "WSA: shared PostgreSQL debezium password (from shared infra output)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "shared_dbx_sp_client_id" {
+  description = "WSA: Databricks SP client ID from shared infra (for credentials email)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_dbx_sp_client_secret" {
+  description = "WSA: Ephemeral Databricks SP secret from shared infra (for credentials email)"
+  type        = string
+  sensitive   = true
+  default     = ""
 }

--- a/terraform/azure-demo/.terraform.lock.hcl
+++ b/terraform/azure-demo/.terraform.lock.hcl
@@ -39,46 +39,43 @@ provider "registry.terraform.io/databricks/databricks" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.98.0"
-  constraints = "~> 5.98.0"
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.9.0"
+  constraints = ">= 3.0.0, ~> 3.0"
   hashes = [
-    "h1:neMFK/kP1KT6cTGID+Tkkt8L7PsN9XqwrPDGXVw3WVY=",
-    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
-    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
-    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
-    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
-    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
-    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
-    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
-    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
-    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
-    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
-    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
-    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
-    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+    "h1:caKVAk5GOECNATz8XPruo39n2y6OcntxPblPgl+6QaY=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:39b11a075e4baa4f6ed5c72a8427013d50f43eecc1a7603b73bccf80f952f758",
+    "zh:41484c196c943b39411f561e70a308bd2a71da18155bfec7381ba0bd61361d34",
+    "zh:42068e5da223494beea5f7fcb9057c308cbfa92f96e53c50083e2639216479d8",
+    "zh:464d7da44682443a4b64bfdaf3d0eb53011c6e1471f244f6354c4d5bca18edce",
+    "zh:49f597ea3fac39931ff91e55afd5b5cc91e449920a03716f82509d588aaab708",
+    "zh:6092c376accfc50b555b7a0cd56b76c09abc3d65ac9dd5069063d6f9f1e76d3b",
+    "zh:65326a9f3ac0783c16e05c16422d191f0a926b8d021fd5303c1fdf8dc42f16e9",
+    "zh:784214ed809347d74562bb38194c0cef57831eaa621ba3b7cdd3fe7a7a76d844",
+    "zh:b4233f9bc791adc7d6643507fa5b47360a21125763a072d953586151cacb65f9",
+    "zh:c4ecdd995ff99b7e362e087c45f080816bcf097da5be257c87b912210e45dd3e",
+    "zh:f0122771f71cb98248e70cdd6c2ccd3bffb34e79d19897fa28b785c86b2312ed",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/http" {
-  version     = "3.4.5"
-  constraints = "~> 3.4.0"
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.80.0"
+  constraints = ">= 4.0.0, ~> 4.0"
   hashes = [
-    "h1:eSVCYfvn5JyV3LC0+mrLlLtgLv4B+RWeNqz02miBcMY=",
-    "zh:2072006c177efc101471f3d5eb8e1d8e6c68778cbfd6db3d3f22f59cfe6ce6ae",
-    "zh:3ac4cc0efe11ee054300769cfcc37491433937a8824621d1f8f7a18e7401da87",
-    "zh:63997e5457c9ddf9cfff17bd7bf9f083cbeff3105452045662109dd6be499ef9",
+    "h1:R8n0T2WWUxa65nw64W/Q+M2X9My84/lebmKwAzixlu8=",
+    "zh:1287b44676ced8f2d8131b1746a027f05edba2e5aa7e3ecdbaa6887aaad68431",
+    "zh:1ae7263cafd4f9ffff6a595190ee940af929bda026bddd7db2cd733596878597",
+    "zh:3ec5bdbce4ce98db2f850d98c75024d7267df9809ad8ef425ec21e727858d150",
+    "zh:4a33b42598fe7337d8e78b0ab57daff65a0689e0896c1232d380511e0a011dc7",
+    "zh:69348cf4aaa49869ccb66aedc1ff99aac59fccf7c1971b3829d5f372291d847a",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:826819bb8ab7d6e3095f597083d5b1ab93d1854312b9e1b6c18288fff9664f34",
-    "zh:8ad74e7d8ec2e226a73d49c7c317108f61a4cb803972fb3f945d1709d5115fcd",
-    "zh:a609ca9e0c91d250ac80295e39d5f524e8c0872d33ba8fde3c3e41893b4b015d",
-    "zh:ae07d19babc452f63f6a6511b944990e819dc20687b6c8f01d1676812f5ada53",
-    "zh:b7c827dc32a1a5d77185a78cd391b01217894b384f58169f98a96d683730d8ce",
-    "zh:d045e3db9f5e39ce78860d3fd94e04604fcbe246f6fe346ee50a971f936e9ccd",
-    "zh:ec28f9b52c74edd47eebbb5c254a6df5706360cde5ccd65097976efca23a2977",
-    "zh:f24982eaa7d34fd66554c3cf94873713a0dff14da9ea4c4be0cc76f1a6146d59",
+    "zh:7cfbfca11cb85713fa0666f788b5c5778f38ff88b1956c61a638b1fb0a02773c",
+    "zh:7e889f4d9c5907e037f3ea486dd517e5481342625635b10a4cc7338a5571cdc0",
+    "zh:85bc8cf551491ffcdf841110922b69d040090f379924896b2ccbc337cc7cb41e",
+    "zh:99585400adafdc8aedd37cb1e715e986ce39612ba18bab34fd8749aae37593d7",
+    "zh:a1d4ccf5e1afb4e440119b3ff2e41c3192979ea9b1735cc9d91a7fb8684339e0",
+    "zh:ea3be732d424c36634dd105425879ea7610224cada0c59ed6172ce67b610289d",
   ]
 }
 
@@ -105,7 +102,7 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.3.0"
-  constraints = "~> 3.2"
+  constraints = ">= 3.2.0, ~> 3.2"
   hashes = [
     "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
@@ -147,7 +144,7 @@ provider "registry.terraform.io/hashicorp/random" {
 
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.14.0"
-  constraints = ">= 0.9.0"
+  constraints = ">= 0.9.0, ~> 0.9"
   hashes = [
     "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
     "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
@@ -163,26 +160,5 @@ provider "registry.terraform.io/hashicorp/time" {
     "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
     "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
     "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version     = "4.3.0"
-  constraints = "~> 4.0"
-  hashes = [
-    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
-    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
-    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
-    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
-    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
-    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
-    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
-    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
-    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
-    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
-    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
-    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
-    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/azure-demo/docker-compose.yml
+++ b/terraform/azure-demo/docker-compose.yml
@@ -1,0 +1,47 @@
+# Docker Compose for Terraform Workshop — Azure Demo Mode
+#
+# Usage:
+#   docker-compose build                                    # Build the container (one-time)
+#   docker-compose run --rm terraform                       # Interactive shell
+#   docker-compose run --rm terraform -c "terraform init"   # Run specific command
+#
+# Azure Credentials (in priority order):
+#   1. Service principal env vars: ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID, ARM_SUBSCRIPTION_ID
+#   2. Host machine's ~/.azure directory (mounted read-only, from `az login`)
+
+services:
+  terraform:
+    build:
+      context: ../azure
+      dockerfile: Dockerfile
+    image: workshop-terraform-azure:latest
+    container_name: workshop-terraform-azure-demo
+    volumes:
+      # Mount repo root so ../../data is accessible for generated files
+      - ../..:/workspace
+      # Mount host's Azure credentials (read-only)
+      - ~/.azure:/root/.azure-host:ro
+    environment:
+      # Azure credentials from environment variables
+      - ARM_CLIENT_ID
+      - ARM_CLIENT_SECRET
+      - ARM_TENANT_ID
+      - ARM_SUBSCRIPTION_ID
+      # Azure host config location (used by entrypoint script)
+      - AZURE_HOST_CONFIG=/root/.azure-host
+      # Terraform variables (alternative to terraform.tfvars)
+      - TF_VAR_confluent_cloud_api_key
+      - TF_VAR_confluent_cloud_api_secret
+      - TF_VAR_azure_subscription_id
+      - TF_VAR_azure_tenant_id
+      - TF_VAR_databricks_host
+      - TF_VAR_databricks_service_principal_client_id
+      - TF_VAR_databricks_service_principal_client_secret
+      - TF_VAR_databricks_account_id
+      - TF_VAR_databricks_user_email
+      - TF_VAR_confluent_cloud_email
+      - TF_VAR_cloud_region
+      - TF_VAR_prefix
+    working_dir: /workspace/terraform/azure-demo
+    stdin_open: true
+    tty: true

--- a/terraform/azure-demo/main.tf
+++ b/terraform/azure-demo/main.tf
@@ -1,0 +1,679 @@
+# ===============================
+# Root Terraform Configuration — Azure Demo Mode
+# ===============================
+# Orchestrates all modules for the Tableflow Databricks Workshop in demo mode
+# on Azure. Provisions everything that self-service mode requires PLUS:
+#   - Unity Catalog integration (confluent_catalog_integration)
+#   - Flink Materialized Table (denormalized_hotel_bookings)
+#   - Tableflow topic enablement (clickstream, denormalized_hotel_bookings)
+#   - Databricks notebook import (marketing agent)
+#
+# Note: reviews_with_sentiment and hotel_performance are intentionally omitted.
+# AI_SENTIMENT (Confluent Cloud for Apache Flink) is currently AWS-only
+# (announced 2026-03-19):
+# https://docs.confluent.io/cloud/current/release-notes/index.html#march-19-2026
+# When Azure support lands, set enable_reviews_with_sentiment = true on
+# flink_ctas and tableflow_topics below (and optionally add hotel_performance).
+#
+# Supports two modes:
+#   Self-service: all resources created per-account (shared_* vars empty)
+#   WSA mode:     shared infra provided via shared_* vars
+
+# ===============================
+# Random ID for Resource Naming
+# ===============================
+
+resource "random_id" "env_display_id" {
+  byte_length = 4
+}
+
+# ===============================
+# Azure Client Config (for tenant_id fallback when variable is null)
+# ===============================
+
+data "azurerm_client_config" "current" {}
+
+# ===============================
+# Local Variables
+# ===============================
+
+locals {
+  prefix          = "${var.prefix}-${var.project_name}"
+  resource_suffix = random_id.env_display_id.hex
+
+  # WSA: use per-account email when provided, fall back to self-service email
+  effective_email = var.account_email != "" ? var.account_email : var.confluent_cloud_email
+
+  # When shared_* vars are set, use them; otherwise use per-account module outputs.
+  use_shared = var.shared_resource_group_name != ""
+
+  effective_resource_group_name        = local.use_shared ? var.shared_resource_group_name : azurerm_resource_group.main[0].name
+  effective_storage_account_name       = local.use_shared ? var.shared_storage_account_name : module.storage[0].storage_account_name
+  effective_storage_account_id         = local.use_shared ? var.shared_storage_account_id : module.storage[0].storage_account_id
+  effective_storage_container_name     = local.use_shared ? var.shared_storage_container_name : module.storage[0].container_name
+  effective_abfss_url                  = local.use_shared ? "abfss://${var.shared_storage_container_name}@${var.shared_storage_account_name}.dfs.core.windows.net/" : module.storage[0].abfss_url
+  effective_postgres_host              = local.use_shared ? var.shared_postgres_public_ip : module.postgres[0].fqdn
+  effective_postgres_db_password       = local.use_shared && var.shared_postgres_db_password != "" ? var.shared_postgres_db_password : var.postgres_db_password
+  effective_postgres_debezium_password = local.use_shared && var.shared_postgres_debezium_password != "" ? var.shared_postgres_debezium_password : var.postgres_debezium_password
+  effective_resource_group_id          = local.use_shared ? var.shared_resource_group_id : azurerm_resource_group.main[0].id
+
+  common_tags = {
+    Project     = "Hospitality AI Agent"
+    Environment = var.environment
+    Created_by  = "Terraform"
+    owner_email = local.effective_email
+    mode        = "demo"
+  }
+
+  # Databricks workspace URL — auto-provisioned or pre-existing
+  create_workspace         = var.databricks_host == ""
+  databricks_workspace_url = local.create_workspace ? module.databricks_workspace.workspace_url : var.databricks_host
+  databricks_workspace_id  = local.create_workspace ? module.databricks_workspace.workspace_id : null
+
+  effective_access_connector_id = local.use_shared ? var.shared_dbx_access_connector_id : module.databricks_access_connector[0].access_connector_id
+
+  # Topic names: WSA/shared uses CDC-prefixed topics; standalone demo uses plain names
+  clickstream_topic = local.use_shared ? "riverhotel.cdc.clickstream" : "clickstream"
+  bookings_topic    = local.use_shared ? "riverhotel.cdc.bookings" : "bookings"
+  reviews_topic     = local.use_shared ? "riverhotel.cdc.reviews" : "reviews"
+  customer_topic    = "riverhotel.cdc.customer"
+  hotel_topic       = "riverhotel.cdc.hotel"
+}
+
+# ===============================
+# Azure Resource Group
+# ===============================
+
+resource "azurerm_resource_group" "main" {
+  count    = local.use_shared ? 0 : 1
+  name     = var.azure_resource_group_name
+  location = var.cloud_region
+
+  tags = local.common_tags
+}
+
+# ===============================
+# Azure Storage (ADLS Gen2)
+# ===============================
+
+module "storage" {
+  count  = local.use_shared ? 0 : 1
+  source = "../azure/modules/azure-storage"
+
+  storage_account_prefix = var.azure_storage_account_prefix
+  resource_suffix        = local.resource_suffix
+  resource_group_name    = local.effective_resource_group_name
+  region                 = var.cloud_region
+  common_tags            = local.common_tags
+}
+
+# ===============================
+# Confluent Platform
+# ===============================
+
+module "confluent_platform" {
+  source = "../modules/confluent-platform"
+
+  prefix          = local.prefix
+  resource_suffix = local.resource_suffix
+  cloud           = "AZURE"
+  cloud_region    = var.cloud_region
+  cluster_type    = var.cluster_type
+  environment_id  = var.cc_environment_id
+  user_email      = local.effective_email
+}
+
+# ===============================
+# Confluent Tableflow Provider Integration (Azure two-step)
+# ===============================
+
+module "tableflow" {
+  source = "../modules/confluent-tableflow"
+
+  prefix          = local.prefix
+  resource_suffix = local.resource_suffix
+  environment_id  = module.confluent_platform.environment_id
+  cloud_provider  = "azure"
+  azure_tenant_id = coalesce(var.azure_tenant_id, data.azurerm_client_config.current.tenant_id)
+
+  depends_on = [module.confluent_platform]
+}
+
+# ===============================
+# Azure Identity (Confluent SP + RBAC for Tableflow → ADLS Gen2)
+# ===============================
+
+module "identity" {
+  source = "../azure/modules/azure-identity"
+
+  confluent_multi_tenant_app_id = module.tableflow.azure_confluent_multi_tenant_app_id
+  storage_account_id            = local.effective_storage_account_id
+  resource_group_id             = local.effective_resource_group_id
+
+  depends_on = [module.tableflow]
+}
+
+# ===============================
+# Confluent Flink
+# ===============================
+
+module "flink" {
+  source = "../modules/confluent-flink"
+
+  prefix                      = local.prefix
+  resource_suffix             = local.resource_suffix
+  cloud                       = "AZURE"
+  cloud_region                = var.cloud_region
+  environment_id              = module.confluent_platform.environment_id
+  service_account_id          = module.confluent_platform.service_account_id
+  service_account_api_version = module.confluent_platform.service_account_api_version
+  service_account_kind        = module.confluent_platform.service_account_kind
+
+  depends_on = [module.confluent_platform]
+}
+
+# ===============================
+# Azure PostgreSQL (Flexible Server)
+# ===============================
+
+module "postgres" {
+  count  = local.use_shared ? 0 : 1
+  source = "../azure/modules/azure-postgres"
+
+  prefix              = local.prefix
+  resource_suffix     = local.resource_suffix
+  resource_group_name = local.effective_resource_group_name
+  region              = var.cloud_region
+  sku_name            = var.postgres_sku_name
+  storage_mb          = var.postgres_storage_mb
+  admin_username      = var.postgres_db_username
+  admin_password      = local.effective_postgres_db_password
+  db_name             = var.postgres_db_name
+  debezium_username   = var.postgres_debezium_username
+  debezium_password   = local.effective_postgres_debezium_password
+  common_tags         = local.common_tags
+
+  depends_on = [azurerm_resource_group.main]
+}
+
+# ===============================
+# Cluster Networking (Private Link to PostgreSQL)
+# ===============================
+
+resource "confluent_network" "azure_egress" {
+  count            = local.use_shared ? 0 : 1
+  display_name     = "${local.prefix}-network-${local.resource_suffix}"
+  cloud            = "AZURE"
+  region           = var.cloud_region
+  connection_types = ["PRIVATELINK"]
+
+  environment {
+    id = module.confluent_platform.environment_id
+  }
+
+  depends_on = [module.confluent_platform]
+}
+
+resource "confluent_access_point" "postgres" {
+  count        = local.use_shared ? 0 : 1
+  display_name = "${local.prefix}-postgres-ap-${local.resource_suffix}"
+
+  environment {
+    id = module.confluent_platform.environment_id
+  }
+
+  gateway {
+    id = confluent_network.azure_egress[0].gateway[0].id
+  }
+
+  azure_egress_private_link_endpoint {
+    private_link_service_resource_id = module.postgres[0].server_id
+    private_link_subresource_name    = "postgresqlServer"
+  }
+
+  depends_on = [confluent_network.azure_egress, module.postgres]
+}
+
+# ===============================
+# Databricks Workspace (auto-provisioned if no host provided)
+# ===============================
+
+module "databricks_workspace" {
+  source = "../azure/modules/azure-databricks-workspace"
+
+  prefix              = local.prefix
+  resource_suffix     = local.resource_suffix
+  resource_group_name = local.effective_resource_group_name
+  region              = var.cloud_region
+  create_workspace    = local.create_workspace
+  common_tags         = local.common_tags
+}
+
+# ===============================
+# Databricks Access Connector (managed identity → ADLS Gen2)
+# ===============================
+
+module "databricks_access_connector" {
+  count  = local.use_shared ? 0 : 1
+  source = "../azure/modules/azure-databricks-access-connector"
+
+  prefix              = local.prefix
+  resource_suffix     = local.resource_suffix
+  resource_group_name = local.effective_resource_group_name
+  region              = var.cloud_region
+  storage_account_id  = local.effective_storage_account_id
+  common_tags         = local.common_tags
+}
+
+# ===============================
+# Databricks Metastore (Unity Catalog)
+# ===============================
+
+module "databricks_metastore" {
+  count  = local.use_shared ? 0 : 1
+  source = "../azure/modules/azure-databricks-metastore"
+
+  providers = {
+    databricks.workspace = databricks.workspace
+  }
+
+  workspace_id         = local.databricks_workspace_id
+  storage_account_name = local.effective_storage_account_name
+  container_name       = local.effective_storage_container_name
+  access_connector_id  = local.effective_access_connector_id
+  region               = var.cloud_region
+  resource_suffix      = local.resource_suffix
+  create_sql_warehouse = local.create_workspace
+
+  depends_on = [module.databricks_workspace]
+}
+
+# ===============================
+# Databricks Storage Credential (shared module — Azure path)
+# ===============================
+
+module "databricks" {
+  source = "../modules/databricks"
+
+  providers = {
+    databricks.workspace = databricks.workspace
+  }
+
+  prefix                      = local.prefix
+  resource_suffix             = local.resource_suffix
+  cloud_provider              = "azure"
+  azure_access_connector_id   = local.effective_access_connector_id
+  user_email                  = var.databricks_user_email
+  sso_email                   = var.databricks_sso_email
+  service_principal_client_id = var.databricks_service_principal_client_id
+  kafka_cluster_id            = module.confluent_platform.kafka_cluster_id
+  sql_warehouse_name          = var.databricks_sql_warehouse_name
+
+  # WSA mode (shared infra): create users via SCIM and skip admins membership.
+  # Self-service mode: look up the existing user who owns the workspace.
+  lookup_existing_users = !local.use_shared
+  add_user_to_admins    = !local.use_shared
+}
+
+# ===============================
+# Databricks External Location
+# ===============================
+
+resource "databricks_external_location" "main" {
+  count    = local.use_shared ? 0 : 1
+  provider = databricks.workspace
+
+  name            = "${local.prefix}-external-location-${local.resource_suffix}"
+  url             = "${local.effective_abfss_url}${local.prefix}/"
+  credential_name = module.databricks.storage_credential_name
+  comment         = "External location for Unity Catalog ADLS Gen2 access"
+  force_destroy   = true
+
+  depends_on = [module.databricks]
+}
+
+# ===============================
+# Databricks External Location Grants
+# ===============================
+
+resource "databricks_grants" "external_location" {
+  count    = local.use_shared ? 0 : 1
+  provider = databricks.workspace
+
+  external_location = databricks_external_location.main[0].name
+
+  grant {
+    principal = var.databricks_user_email
+    privileges = [
+      "ALL_PRIVILEGES",
+      "MANAGE",
+      "CREATE_EXTERNAL_TABLE",
+      "CREATE_EXTERNAL_VOLUME",
+      "READ_FILES",
+      "WRITE_FILES",
+      "CREATE_MANAGED_STORAGE",
+      "EXTERNAL_USE_LOCATION"
+    ]
+  }
+
+  grant {
+    principal = var.databricks_service_principal_client_id
+    privileges = [
+      "ALL_PRIVILEGES",
+      "MANAGE",
+      "CREATE_EXTERNAL_TABLE",
+      "CREATE_EXTERNAL_VOLUME",
+      "READ_FILES",
+      "WRITE_FILES",
+      "CREATE_MANAGED_STORAGE",
+      "EXTERNAL_USE_LOCATION"
+    ]
+  }
+}
+
+# ===============================
+# Databricks Catalog
+# ===============================
+
+resource "databricks_catalog" "main" {
+  provider = databricks.workspace
+
+  name          = "${local.prefix}-${local.resource_suffix}"
+  comment       = "Dedicated catalog for Confluent Tableflow integration"
+  storage_root  = "${local.effective_abfss_url}${local.prefix}/catalog/"
+  force_destroy = true
+
+  depends_on = [module.databricks]
+}
+
+# ===============================
+# Databricks Catalog Grants
+# ===============================
+
+resource "databricks_grants" "catalog" {
+  provider = databricks.workspace
+
+  catalog = databricks_catalog.main.name
+
+  grant {
+    principal = var.databricks_user_email
+    privileges = [
+      "ALL_PRIVILEGES",
+      "USE_CATALOG",
+      "CREATE_SCHEMA",
+      "USE_SCHEMA",
+      "EXTERNAL_USE_SCHEMA"
+    ]
+  }
+
+  grant {
+    principal = var.databricks_service_principal_client_id
+    privileges = [
+      "ALL_PRIVILEGES",
+      "USE_CATALOG",
+      "CREATE_SCHEMA",
+      "USE_SCHEMA",
+      "EXTERNAL_USE_SCHEMA",
+      "CREATE_TABLE"
+    ]
+  }
+
+  dynamic "grant" {
+    for_each = var.databricks_sso_email != "" ? [var.databricks_sso_email] : []
+    content {
+      principal = grant.value
+      privileges = [
+        "ALL_PRIVILEGES",
+        "USE_CATALOG",
+        "CREATE_SCHEMA",
+        "USE_SCHEMA",
+        "EXTERNAL_USE_SCHEMA"
+      ]
+    }
+  }
+
+  depends_on = [databricks_catalog.main]
+}
+
+# ===============================
+# Data Quality Rules (Data Contracts)
+# ===============================
+# Demo standalone path uses self-service generators (direct Kafka), so register
+# all schemas with no topic prefix. Skip in WSA/shared mode (CDC collision).
+
+module "data_contracts" {
+  source = "../modules/confluent-data-contracts"
+
+  count = local.use_shared ? 0 : 1
+
+  environment_id             = module.confluent_platform.environment_id
+  kafka_cluster_id           = module.confluent_platform.kafka_cluster_id
+  kafka_rest_endpoint        = module.confluent_platform.kafka_rest_endpoint
+  kafka_api_key              = module.confluent_platform.kafka_api_key
+  kafka_api_secret           = module.confluent_platform.kafka_api_secret
+  schema_registry_id         = module.confluent_platform.schema_registry_id
+  schema_registry_endpoint   = module.confluent_platform.schema_registry_endpoint
+  schema_registry_api_key    = module.confluent_platform.schema_registry_api_key
+  schema_registry_api_secret = module.confluent_platform.schema_registry_api_secret
+  schemas_dir                = "${path.module}/../../data/schemas"
+  topic_prefix               = ""
+  register_all_schemas       = true
+
+  depends_on = [module.confluent_platform]
+}
+
+# ===============================
+# Confluent PostgreSQL CDC Connector
+# ===============================
+
+module "connectors" {
+  source = "../modules/confluent-connectors"
+
+  prefix               = local.prefix
+  environment_id       = module.confluent_platform.environment_id
+  kafka_cluster_id     = module.confluent_platform.kafka_cluster_id
+  service_account_id   = module.confluent_platform.service_account_id
+  postgres_hostname    = local.effective_postgres_host
+  postgres_port        = var.postgres_db_port
+  database_name        = var.postgres_db_name
+  debezium_username    = var.postgres_debezium_username
+  debezium_password    = local.effective_postgres_debezium_password
+  table_include_list   = var.table_include_list
+  ssh_key_path         = ""
+  initial_wait_seconds = local.use_shared ? 0 : 90
+
+  depends_on = [module.postgres, module.confluent_platform, confluent_access_point.postgres, module.data_contracts]
+}
+
+# ===============================
+# Confluent Flink Statements (ALTER TABLE on CDC topics)
+# ===============================
+
+module "flink_statements" {
+  source = "../modules/confluent-flink-statements"
+
+  organization_id            = module.confluent_platform.organization_id
+  environment_id             = module.confluent_platform.environment_id
+  environment_name           = module.confluent_platform.environment_name
+  kafka_cluster_display_name = module.confluent_platform.kafka_cluster_display_name
+  compute_pool_id            = module.flink.compute_pool_id
+  service_account_id         = module.confluent_platform.service_account_id
+  flink_api_key              = module.flink.flink_api_key
+  flink_api_secret           = module.flink.flink_api_secret
+  flink_rest_endpoint        = module.flink.flink_rest_endpoint
+
+  clickstream_topic = local.clickstream_topic
+  bookings_topic    = local.bookings_topic
+  reviews_topic     = local.reviews_topic
+
+  depends_on = [module.connectors, module.flink]
+}
+
+# ===============================
+# Data Generator Configuration
+# ===============================
+
+module "data_generator" {
+  count  = local.use_shared ? 0 : 1
+  source = "../modules/data-generator"
+
+  output_path                = "../../data/connections"
+  postgres_hostname          = local.effective_postgres_host
+  postgres_port              = var.postgres_db_port
+  postgres_username          = var.postgres_db_username
+  postgres_password          = local.effective_postgres_db_password
+  postgres_database          = var.postgres_db_name
+  kafka_bootstrap_endpoint   = module.confluent_platform.bootstrap_endpoint_url
+  kafka_api_key              = module.confluent_platform.kafka_api_key
+  kafka_api_secret           = module.confluent_platform.kafka_api_secret
+  schema_registry_endpoint   = module.confluent_platform.schema_registry_endpoint
+  schema_registry_api_key    = module.confluent_platform.schema_registry_api_key
+  schema_registry_api_secret = module.confluent_platform.schema_registry_api_secret
+
+  depends_on = [module.confluent_platform]
+}
+
+# =========================================================================
+# DEMO MODE RESOURCES
+# =========================================================================
+# Everything below this line is specific to demo mode and does not exist
+# in the self-service terraform/azure/ root.
+
+# ===============================
+# Tableflow API Key
+# ===============================
+
+resource "confluent_api_key" "tableflow" {
+  display_name = "${local.prefix}-tableflow-${local.resource_suffix}"
+
+  owner {
+    id          = module.confluent_platform.service_account_id
+    api_version = module.confluent_platform.service_account_api_version
+    kind        = module.confluent_platform.service_account_kind
+  }
+
+  managed_resource {
+    id          = "tableflow"
+    api_version = "tableflow/v1"
+    kind        = "Tableflow"
+
+    environment {
+      id = module.confluent_platform.environment_id
+    }
+  }
+
+  depends_on = [module.confluent_platform]
+}
+
+# ===============================
+# Unity Catalog Integration
+# ===============================
+
+module "catalog_integration" {
+  source = "../modules/confluent-catalog-integration"
+
+  prefix           = local.prefix
+  resource_suffix  = local.resource_suffix
+  environment_id   = module.confluent_platform.environment_id
+  kafka_cluster_id = module.confluent_platform.kafka_cluster_id
+
+  databricks_workspace_url    = local.databricks_workspace_url
+  databricks_catalog_name     = databricks_catalog.main.name
+  databricks_sp_client_id     = var.databricks_service_principal_client_id
+  databricks_sp_client_secret = var.databricks_service_principal_client_secret
+
+  api_key    = confluent_api_key.tableflow.id
+  api_secret = confluent_api_key.tableflow.secret
+
+  depends_on = [
+    module.flink_statements,
+    module.connectors,
+    databricks_catalog.main,
+    confluent_api_key.tableflow,
+  ]
+}
+
+# ===============================
+# Flink Materialized Tables
+# ===============================
+# Creates denormalized_hotel_bookings only.
+#
+# reviews_with_sentiment is DISABLED on Azure — AI_SENTIMENT is AWS-only today.
+# See: https://docs.confluent.io/cloud/current/release-notes/index.html#march-19-2026
+#
+# To enable when Azure support is available:
+#   enable_reviews_with_sentiment = true
+# (also flip the same flag on module.tableflow_topics below)
+
+module "flink_ctas" {
+  source = "../modules/confluent-flink-ctas"
+
+  organization_id            = module.confluent_platform.organization_id
+  environment_id             = module.confluent_platform.environment_id
+  environment_name           = module.confluent_platform.environment_name
+  kafka_cluster_id           = module.confluent_platform.kafka_cluster_id
+  kafka_cluster_display_name = module.confluent_platform.kafka_cluster_display_name
+  compute_pool_id            = module.flink.compute_pool_id
+  service_account_id         = module.confluent_platform.service_account_id
+  flink_api_key              = module.flink.flink_api_key
+  flink_api_secret           = module.flink.flink_api_secret
+  flink_rest_endpoint        = module.flink.flink_rest_endpoint
+
+  bookings_topic = local.bookings_topic
+  reviews_topic  = local.reviews_topic
+  customer_topic = local.customer_topic
+  hotel_topic    = local.hotel_topic
+
+  # AWS-only today — do not enable until AI_SENTIMENT is available on Azure
+  enable_reviews_with_sentiment = false
+
+  # flink_statements configures changelog/watermark; connectors ensure CDC topics exist
+  depends_on = [module.flink_statements, module.connectors]
+}
+
+# ===============================
+# Tableflow Topic Enablement
+# ===============================
+# Enables Tableflow on clickstream + denormalized_hotel_bookings.
+# reviews_with_sentiment Tableflow is skipped (same AI_SENTIMENT Azure gap).
+
+module "tableflow_topics" {
+  source = "../modules/confluent-tableflow-topics"
+
+  environment_id   = module.confluent_platform.environment_id
+  kafka_cluster_id = module.confluent_platform.kafka_cluster_id
+  cloud_provider   = "azure"
+
+  storage_account_name    = local.effective_storage_account_name
+  container_name          = local.effective_storage_container_name
+  provider_integration_id = module.tableflow.integration_id
+  clickstream_topic       = local.clickstream_topic
+
+  # Keep in sync with module.flink_ctas.enable_reviews_with_sentiment
+  enable_reviews_with_sentiment = false
+
+  api_key    = confluent_api_key.tableflow.id
+  api_secret = confluent_api_key.tableflow.secret
+
+  depends_on = [
+    module.flink_ctas,
+    module.catalog_integration,
+    module.identity,
+    confluent_api_key.tableflow,
+  ]
+}
+
+# ===============================
+# Databricks Notebook Import
+# ===============================
+
+resource "databricks_notebook" "marketing_agent" {
+  provider = databricks.workspace
+
+  path     = "/Shared/workshop/river_hotel_marketing_agent"
+  language = "PYTHON"
+  source   = "${path.module}/../../labs/shared/river_hotel_marketing_agent.ipynb"
+  format   = "JUPYTER"
+
+  depends_on = [databricks_catalog.main]
+}

--- a/terraform/azure-demo/outputs.tf
+++ b/terraform/azure-demo/outputs.tf
@@ -1,5 +1,5 @@
 # ===============================
-# Root Outputs — Demo Mode
+# Root Outputs — Azure Demo Mode
 # ===============================
 
 # ===============================
@@ -9,15 +9,16 @@
 output "workshop_summary" {
   description = "Complete workshop environment summary"
   value = {
-    postgres_public_dns          = local.effective_postgres_dns
-    postgres_connection          = "postgresql://postgres:***@${local.effective_postgres_dns}:5432/${var.postgres_db_name}"
+    postgres_host                = local.effective_postgres_host
+    postgres_connection          = "postgresql://${var.postgres_db_username}:***@${local.effective_postgres_host}:5432/${var.postgres_db_name}"
     environment_id               = module.confluent_platform.environment_id
     kafka_cluster_id             = module.confluent_platform.kafka_cluster_id
     flink_compute_pool           = module.flink.compute_pool_id
     schema_registry_url          = module.confluent_platform.schema_registry_endpoint
     databricks_catalog           = databricks_catalog.main.name
-    databricks_external_location = local.use_shared ? "shared (aws-shared)" : databricks_external_location.main[0].name
-    s3_bucket                    = local.effective_s3_bucket_name
+    databricks_external_location = local.use_shared ? "shared (azure-shared)" : databricks_external_location.main[0].name
+    storage_account              = local.effective_storage_account_name
+    storage_container            = local.effective_storage_container_name
     confluent_console            = "https://confluent.cloud/environments/${module.confluent_platform.environment_id}"
     connector_url                = "https://confluent.cloud/environments/${module.confluent_platform.environment_id}/clusters/${module.confluent_platform.kafka_cluster_id}/connectors"
   }
@@ -34,59 +35,48 @@ output "demo_status" {
     catalog_integration = module.catalog_integration.display_name
     flink_materialized_tables = {
       denormalized_hotel_bookings = module.flink_ctas.denormalized_hotel_bookings_table_name
-      reviews_with_sentiment      = module.flink_ctas.reviews_with_sentiment_table_name
     }
     tableflow_topics = {
       clickstream                 = module.tableflow_topics.clickstream_tableflow_id
       denormalized_hotel_bookings = module.tableflow_topics.denormalized_hotel_bookings_tableflow_id
-      reviews_with_sentiment      = module.tableflow_topics.reviews_with_sentiment_tableflow_id
     }
     notebook_path = databricks_notebook.marketing_agent.path
+    notes         = "reviews_with_sentiment Tableflow skipped — AI_SENTIMENT is AWS-only (https://docs.confluent.io/cloud/current/release-notes/index.html#march-19-2026)"
     links = {
       confluent_tableflow = "https://confluent.cloud/environments/${module.confluent_platform.environment_id}/clusters/${module.confluent_platform.kafka_cluster_id}/tableflow"
       confluent_flink     = "https://confluent.cloud/environments/${module.confluent_platform.environment_id}/flink/compute-pools/${module.flink.compute_pool_id}"
-      databricks_catalog  = "${var.databricks_host}#/catalog/${databricks_catalog.main.name}"
+      databricks_catalog  = "${local.databricks_workspace_url}#/catalog/${databricks_catalog.main.name}"
     }
   }
 }
 
 # ===============================
-# AWS Outputs
+# Azure Outputs
 # ===============================
 
-output "aws_networking" {
-  description = "AWS networking resources"
-  value = {
-    vpc_id           = local.effective_vpc_id
-    public_subnet_id = local.effective_subnet_id
-    aws_account_id   = local.effective_aws_account
-  }
+output "resource_group_name" {
+  description = "Azure Resource Group name"
+  value       = local.effective_resource_group_name
 }
 
-output "aws_postgres" {
-  description = "PostgreSQL instance details"
-  value = {
-    public_ip  = local.effective_postgres_ip
-    public_dns = local.effective_postgres_dns
-    connection = "postgresql://postgres:***@${local.effective_postgres_dns}:5432/${var.postgres_db_name}"
-  }
+output "storage_account_name" {
+  description = "ADLS Gen2 Storage Account name"
+  value       = local.effective_storage_account_name
 }
 
-output "aws_s3" {
-  description = "S3 bucket details"
-  value = {
-    bucket_name = local.effective_s3_bucket_name
-    bucket_arn  = local.effective_s3_bucket_arn
-    bucket_url  = local.effective_s3_bucket_url
-  }
+output "storage_container_name" {
+  description = "ADLS Gen2 container name"
+  value       = local.effective_storage_container_name
 }
 
-output "aws_iam" {
-  description = "IAM role details"
-  value = {
-    role_arn  = module.iam.role_arn
-    role_name = module.iam.role_name
-  }
+output "storage_abfss_url" {
+  description = "ADLS Gen2 abfss:// URL"
+  value       = local.effective_abfss_url
+}
+
+output "postgres_fqdn" {
+  description = "PostgreSQL hostname (Flexible Server FQDN or shared VM IP)"
+  value       = local.effective_postgres_host
 }
 
 # ===============================
@@ -122,8 +112,6 @@ output "confluent_tableflow" {
   description = "Tableflow provider integration details"
   value = {
     integration_id = module.tableflow.integration_id
-    iam_role_arn   = module.tableflow.iam_role_arn
-    external_id    = module.tableflow.external_id
   }
 }
 
@@ -154,10 +142,21 @@ output "confluent_credentials" {
 # Databricks Outputs
 # ===============================
 
+output "databricks_workspace_url" {
+  description = "Databricks workspace URL"
+  value       = local.databricks_workspace_url
+}
+
+output "databricks_catalog_name" {
+  description = "Databricks Unity Catalog name"
+  value       = databricks_catalog.main.name
+}
+
 output "databricks_integration" {
   description = "Databricks Unity Catalog integration details"
   value = {
-    s3_bucket_name         = local.effective_s3_bucket_name
+    storage_account_name   = local.effective_storage_account_name
+    storage_container_name = local.effective_storage_container_name
     catalog_name           = databricks_catalog.main.name
     databricks_schema_name = module.databricks.databricks_schema_name
     sql_warehouse_id       = module.databricks.sql_warehouse_id
@@ -171,32 +170,14 @@ output "databricks_integration" {
 output "next_steps" {
   description = "Workshop next steps"
   value       = <<-EOT
-    Demo Mode Deployment Complete!
+    Azure Demo Mode Deployment Complete!
 
     Next Steps:
     1. Wait 10-15 minutes for Tableflow to sync data to Delta Lake
-    2. Verify tables in Databricks: ${var.databricks_host}#/catalog/${databricks_catalog.main.name}
-    3. Verify the hotel_performance view: SELECT * FROM hotel_performance LIMIT 10
+    2. Verify tables in Databricks: ${local.databricks_workspace_url}#/catalog/${databricks_catalog.main.name}
+    3. Explore denormalized_hotel_bookings and clickstream (reviews_with_sentiment skipped — AI_SENTIMENT is AWS-only; see Confluent Cloud release notes 2026-03-19)
     4. Explore with Genie and run the pre-imported notebook at: /Shared/workshop/river_hotel_marketing_agent
     5. When done: terraform destroy -auto-approve
-  EOT
-}
-
-output "databricks_manual_step" {
-  description = "Manual step required for Databricks external data access"
-  value       = <<-EOT
-    MANUAL STEP REQUIRED
-
-    A metastore admin must enable "External data access" on your Unity Catalog metastore.
-
-    Steps (requires metastore admin privileges):
-    1. In Databricks workspace: ${var.databricks_host}
-    2. Click "Catalog" in the left navigation
-    3. Click the gear icon at the top of the Catalog pane
-    4. Select "Metastore"
-    5. On the "Details" tab, enable "External data access"
-
-    Reference: https://docs.databricks.com/aws/en/external-access/admin
   EOT
 }
 
@@ -211,7 +192,7 @@ output "cc_environment_url" {
 
 output "dbx_workspace_url" {
   description = "WSA: Databricks workspace URL"
-  value       = var.dbx_workspace_url != "" ? var.dbx_workspace_url : var.databricks_host
+  value       = var.dbx_workspace_url != "" ? var.dbx_workspace_url : local.databricks_workspace_url
 }
 
 output "dbx_sp_client_id" {
@@ -220,7 +201,7 @@ output "dbx_sp_client_id" {
 }
 
 output "dbx_sp_client_secret" {
-  description = "WSA: Databricks SP secret (ephemeral in workshop mode, original in self-service)"
+  description = "WSA: Databricks SP secret (for Tableflow Unity Catalog integration)"
   value       = var.shared_dbx_sp_client_secret != "" ? var.shared_dbx_sp_client_secret : var.databricks_service_principal_client_secret
   sensitive   = true
 }
@@ -228,11 +209,6 @@ output "dbx_sp_client_secret" {
 output "dbx_catalog_name" {
   description = "WSA: Databricks Unity Catalog name"
   value       = databricks_catalog.main.name
-}
-
-output "s3_bucket_name" {
-  description = "WSA: S3 bucket name (for Tableflow storage)"
-  value       = local.effective_s3_bucket_name
 }
 
 output "dbx_schema_name" {

--- a/terraform/azure-demo/providers.tf
+++ b/terraform/azure-demo/providers.tf
@@ -1,0 +1,40 @@
+# ===============================
+# Provider Configuration
+# ===============================
+
+# ===============================
+# Azure Resource Manager
+# ===============================
+
+provider "azurerm" {
+  subscription_id                 = var.azure_subscription_id
+  resource_provider_registrations = "core"
+
+  features {}
+}
+
+# ===============================
+# Azure Active Directory
+# ===============================
+
+provider "azuread" {
+  tenant_id = var.azure_tenant_id
+}
+
+# ===============================
+# Confluent Provider
+# ===============================
+
+provider "confluent" {
+  cloud_api_key    = var.confluent_cloud_api_key
+  cloud_api_secret = var.confluent_cloud_api_secret
+}
+
+# ===============================
+# Databricks Provider (Workspace)
+# ===============================
+
+provider "databricks" {
+  alias = "workspace"
+  host  = local.databricks_workspace_url
+}

--- a/terraform/azure-demo/sample-tfvars
+++ b/terraform/azure-demo/sample-tfvars
@@ -1,0 +1,28 @@
+# ===============================
+# Azure Demo Mode — Terraform Variables
+# ===============================
+# Copy this file to terraform.tfvars and fill in your values.
+
+# --- Your identity ---
+confluent_cloud_email = ""
+prefix                = "neo"
+cloud_region          = "eastus2"
+
+# --- Azure (optional; falls back to ARM_* env vars) ---
+# azure_subscription_id = ""
+# azure_tenant_id       = ""
+
+# --- Confluent Cloud ---
+confluent_cloud_api_key    = ""
+confluent_cloud_api_secret = ""
+
+# --- Databricks ---
+# Leave databricks_host blank to auto-provision a new workspace.
+databricks_host                            = ""  # e.g., https://adb-1234567890.12.azuredatabricks.net
+databricks_account_id                      = ""
+databricks_user_email                      = ""
+databricks_service_principal_client_id     = ""
+databricks_service_principal_client_secret = ""
+
+# Uncomment and set if your Databricks workspace uses a different SQL warehouse name:
+# databricks_sql_warehouse_name = "Serverless Starter Warehouse"

--- a/terraform/azure-demo/variables.tf
+++ b/terraform/azure-demo/variables.tf
@@ -1,0 +1,348 @@
+# ===============================
+# General Variables
+# ===============================
+
+variable "confluent_cloud_email" {
+  description = "Your Confluent Cloud account email — used for EnvironmentAdmin RBAC and resource tagging"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.confluent_cloud_email))
+    error_message = "Must be a valid email address (e.g., user@example.com)."
+  }
+}
+
+variable "prefix" {
+  description = "Call sign to use in prefix for resource names (e.g., your initials or a nickname)"
+  type        = string
+  default     = "neo"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,10}$", var.prefix))
+    error_message = "Must be 2-11 lowercase alphanumeric characters, starting with a letter."
+  }
+}
+
+variable "project_name" {
+  description = "Name of this project to use in prefix for resource names"
+  type        = string
+  default     = "tf-db"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod", "test", "workshop"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod, test, workshop."
+  }
+}
+
+variable "cloud_region" {
+  description = "Azure region (e.g., eastus2, westus2)"
+  type        = string
+  default     = "eastus2"
+}
+
+# ===============================
+# Azure Variables
+# ===============================
+
+variable "azure_subscription_id" {
+  description = "Azure Subscription ID (falls back to ARM_SUBSCRIPTION_ID env var when null)"
+  type        = string
+  default     = null
+}
+
+variable "azure_tenant_id" {
+  description = "Azure AD Tenant ID (falls back to ARM_TENANT_ID env var when null)"
+  type        = string
+  default     = null
+}
+
+variable "azure_resource_group_name" {
+  description = "Name for the Azure resource group"
+  type        = string
+  default     = "tableflow-workshop-rg"
+}
+
+variable "azure_storage_account_prefix" {
+  description = "Prefix for the Azure Storage Account name (3-10 lowercase alphanumeric)"
+  type        = string
+  default     = "cflttflow"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{3,10}$", var.azure_storage_account_prefix))
+    error_message = "Storage account prefix must be 3-10 lowercase alphanumeric characters."
+  }
+}
+
+# ===============================
+# Confluent Cloud Variables
+# ===============================
+
+variable "confluent_cloud_api_key" {
+  description = "Confluent Cloud API key (Cloud Resource Management scope)"
+  type        = string
+  sensitive   = true
+}
+
+variable "confluent_cloud_api_secret" {
+  description = "Confluent Cloud API secret"
+  type        = string
+  sensitive   = true
+}
+
+# ===============================
+# PostgreSQL Variables
+# ===============================
+
+variable "postgres_db_name" {
+  description = "PostgreSQL database name"
+  type        = string
+  default     = "workshop"
+}
+
+variable "postgres_db_username" {
+  description = "PostgreSQL admin username"
+  type        = string
+  default     = "pgadmin"
+
+  validation {
+    condition     = !contains(["postgres", "admin", "administrator", "root", "azure_superuser", "azure_pg_admin"], var.postgres_db_username)
+    error_message = "Username cannot be a reserved PostgreSQL or Azure name."
+  }
+}
+
+variable "postgres_db_password" {
+  description = "PostgreSQL admin password"
+  type        = string
+  sensitive   = true
+  default     = "W0rksh0p!2025"
+}
+
+variable "postgres_db_port" {
+  description = "PostgreSQL port"
+  type        = number
+  default     = 5432
+}
+
+variable "postgres_debezium_username" {
+  description = "Debezium CDC replication username"
+  type        = string
+  default     = "debezium"
+}
+
+variable "postgres_debezium_password" {
+  description = "Debezium CDC replication password"
+  type        = string
+  sensitive   = true
+  default     = "D3bezium!2025"
+}
+
+variable "postgres_sku_name" {
+  description = "PostgreSQL Flexible Server SKU (e.g., B_Standard_B1ms for burstable)"
+  type        = string
+  default     = "B_Standard_B2s"
+}
+
+variable "postgres_storage_mb" {
+  description = "PostgreSQL storage size in MB"
+  type        = number
+  default     = 32768
+}
+
+# ===============================
+# Databricks Variables
+# ===============================
+
+variable "databricks_host" {
+  description = "Databricks workspace URL (e.g., https://adb-1234567890.12.azuredatabricks.net). Leave blank to auto-provision."
+  type        = string
+  default     = ""
+}
+
+variable "databricks_account_id" {
+  description = "Databricks account ID"
+  type        = string
+  default     = ""
+}
+
+variable "databricks_user_email" {
+  description = "Databricks user email for granting permissions"
+  type        = string
+}
+
+variable "databricks_service_principal_client_id" {
+  description = "Databricks Service Principal Application (Client) ID"
+  type        = string
+}
+
+variable "databricks_service_principal_client_secret" {
+  description = "Databricks Service Principal OAuth Secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "databricks_sql_warehouse_name" {
+  description = "Name of the Databricks SQL warehouse to look up (must already exist in the workspace)"
+  type        = string
+  default     = "Serverless Starter Warehouse"
+}
+
+# ---------------------
+# WSA integration variables (defaults preserve backward compatibility for self-service)
+# ---------------------
+
+variable "account_email" {
+  description = "WSA: per-account email (overrides var.confluent_cloud_email when set)"
+  type        = string
+  default     = ""
+}
+
+variable "account_number" {
+  description = "WSA: account number for this run"
+  type        = number
+  default     = 0
+}
+
+variable "cc_environment_id" {
+  description = "WSA: pre-created Confluent Cloud environment ID (skip creation when set)"
+  type        = string
+  default     = ""
+}
+
+variable "cc_environment_name" {
+  description = "WSA: pre-created Confluent Cloud environment name"
+  type        = string
+  default     = ""
+}
+
+variable "databricks_sso_email" {
+  description = "WSA: Azure AD UPN for the participant (e.g., wp2@tenant.onmicrosoft.com). When set, catalog and storage credential grants are added for this identity in addition to databricks_user_email."
+  type        = string
+  default     = ""
+}
+
+variable "dbx_workspace_url" {
+  description = "WSA: Databricks workspace URL for CSV output"
+  type        = string
+  default     = ""
+}
+
+variable "dbx_schema_name" {
+  description = "WSA: Databricks schema name (per-user isolation)"
+  type        = string
+  default     = ""
+}
+
+variable "dbx_catalog_name" {
+  description = "WSA: Databricks catalog name (per-user isolation)"
+  type        = string
+  default     = ""
+}
+
+# ---------------------
+# WSA shared infrastructure variables (skip per-account resources when set)
+# ---------------------
+
+variable "shared_resource_group_name" {
+  description = "WSA: shared resource group name (skips RG creation when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_resource_group_id" {
+  description = "WSA: shared resource group ID (for RBAC scoping in shared mode)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_vnet_id" {
+  description = "WSA: shared VNet ID"
+  type        = string
+  default     = ""
+}
+
+variable "shared_subnet_id" {
+  description = "WSA: shared subnet ID"
+  type        = string
+  default     = ""
+}
+
+variable "shared_storage_account_name" {
+  description = "WSA: shared storage account name (skips storage module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_storage_account_id" {
+  description = "WSA: shared storage account ID"
+  type        = string
+  default     = ""
+}
+
+variable "shared_storage_container_name" {
+  description = "WSA: shared storage container name"
+  type        = string
+  default     = ""
+}
+
+variable "shared_storage_dfs_endpoint" {
+  description = "WSA: shared ADLS Gen2 DFS endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "shared_postgres_public_ip" {
+  description = "WSA: shared PostgreSQL VM public IP (skips postgres module when set)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_postgres_db_password" {
+  description = "WSA: shared PostgreSQL admin password (from shared infra output)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "shared_postgres_debezium_password" {
+  description = "WSA: shared PostgreSQL debezium password (from shared infra output)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "cluster_type" {
+  description = "Confluent Cloud cluster type (standard for WSA/instructor-led, enterprise for self-service)"
+  type        = string
+  default     = "standard"
+}
+
+variable "table_include_list" {
+  description = "CDC connector table include list (all 5 CDC tables when shared, 2 when self-service)"
+  type        = string
+  default     = "cdc.customer,cdc.hotel"
+}
+
+variable "shared_dbx_sp_client_id" {
+  description = "WSA: Databricks SP client ID from shared infra (for credentials email)"
+  type        = string
+  default     = ""
+}
+
+variable "shared_dbx_sp_client_secret" {
+  description = "WSA: Databricks SP secret from shared infra (for credentials email)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "shared_dbx_access_connector_id" {
+  description = "WSA: shared Databricks Access Connector resource ID (skips per-account connector when set)"
+  type        = string
+  default     = ""
+}

--- a/terraform/azure-demo/versions.tf
+++ b/terraform/azure-demo/versions.tf
@@ -1,0 +1,42 @@
+# ===============================
+# Terraform and Provider Version Constraints
+# ===============================
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    confluent = {
+      source  = "confluentinc/confluent"
+      version = ">= 2.64.0"
+    }
+    databricks = {
+      source  = "databricks/databricks"
+      version = "~> 1.79.1"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.4"
+    }
+  }
+}

--- a/terraform/modules/confluent-flink-ctas/main.tf
+++ b/terraform/modules/confluent-flink-ctas/main.tf
@@ -9,6 +9,14 @@
 # Tables created:
 #   1. denormalized_hotel_bookings — temporal joins of bookings + customer + hotel
 #   2. reviews_with_sentiment     — AI_SENTIMENT enrichment on raw reviews
+#
+# Catalog qualification:
+#   confluent_flink_statement sets sql.current-catalog / sql.current-database.
+#   confluent_flink_materialized_table has no equivalent properties, so queries
+#   must fully qualify source tables as `catalog`.`database`.`table`.
+#   Without that, dotted CDC names like riverhotel.cdc.bookings are parsed as
+#   a 3-part identifier (riverhotel / cdc / bookings) when catalog/database
+#   context is empty.
 
 terraform {
   required_providers {
@@ -17,6 +25,25 @@ terraform {
       version = ">= 2.64.0"
     }
   }
+}
+
+locals {
+  # Fully-qualified Flink table refs (catalog = env name, database = cluster name)
+  bookings_fqn = "`${var.environment_name}`.`${var.kafka_cluster_display_name}`.`${var.bookings_topic}`"
+  reviews_fqn  = "`${var.environment_name}`.`${var.kafka_cluster_display_name}`.`${var.reviews_topic}`"
+  customer_fqn = "`${var.environment_name}`.`${var.kafka_cluster_display_name}`.`${var.customer_topic}`"
+  hotel_fqn    = "`${var.environment_name}`.`${var.kafka_cluster_display_name}`.`${var.hotel_topic}`"
+
+  # Timestamp handling differs by bookings source:
+  #   - Self-service / demo Kafka Avro (topic "bookings"): check_in/check_out are
+  #     Avro long epoch millis → Flink BIGINT → need TO_TIMESTAMP_LTZ(x, 3)
+  #   - WSA / instructor-led CDC (topic "riverhotel.cdc.bookings"): Postgres
+  #     TIMESTAMP → Flink TIMESTAMP_LTZ(3) → CAST AS DATE only (TO_TIMESTAMP_LTZ
+  #     with precision arg expects NUMERIC, not TIMESTAMP_LTZ)
+  bookings_from_cdc = can(regex("(?i)(^|\\.)cdc(\\.|$)", var.bookings_topic))
+
+  check_in_expr  = local.bookings_from_cdc ? "CAST(b.`check_in` AS DATE)" : "CAST(TO_TIMESTAMP_LTZ(b.`check_in`, 3) AS DATE)"
+  check_out_expr = local.bookings_from_cdc ? "CAST(b.`check_out` AS DATE)" : "CAST(TO_TIMESTAMP_LTZ(b.`check_out`, 3) AS DATE)"
 }
 
 # ===============================
@@ -57,15 +84,15 @@ resource "confluent_flink_materialized_table" "denormalized_hotel_bookings" {
       b.`price` AS `booking_amount`,
       b.`occupants` AS `guest_count`,
       b.`created_at` AS `booking_date`,
-      CAST(TO_TIMESTAMP_LTZ(b.`check_in`, 3) AS DATE) AS `check_in`,
-      CAST(TO_TIMESTAMP_LTZ(b.`check_out`, 3) AS DATE) AS `check_out`,
+      ${local.check_in_expr} AS `check_in`,
+      ${local.check_out_expr} AS `check_out`,
       c.`email` AS `customer_email`,
       c.`first_name` AS `customer_first_name`,
       c.`rewards_points` AS `customer_rewards_points`
-    FROM `${var.bookings_topic}` b
-      JOIN `${var.customer_topic}` FOR SYSTEM_TIME AS OF b.`created_at` AS c
+    FROM ${local.bookings_fqn} b
+      JOIN ${local.customer_fqn} FOR SYSTEM_TIME AS OF b.`created_at` AS c
         ON c.`email` = b.`customer_email`
-      JOIN `${var.hotel_topic}` FOR SYSTEM_TIME AS OF b.`created_at` AS h
+      JOIN ${local.hotel_fqn} FOR SYSTEM_TIME AS OF b.`created_at` AS h
         ON h.`hotel_id` = b.`hotel_id`
   SQL
 
@@ -88,6 +115,8 @@ resource "confluent_flink_materialized_table" "denormalized_hotel_bookings" {
 # the AI_SENTIMENT built-in function. Pure enrichment — no join.
 
 resource "confluent_flink_materialized_table" "reviews_with_sentiment" {
+  count = var.enable_reviews_with_sentiment ? 1 : 0
+
   organization {
     id = var.organization_id
   }
@@ -130,7 +159,7 @@ resource "confluent_flink_materialized_table" "reviews_with_sentiment" {
           `review_text`,
           ARRAY['cleanliness', 'amenities', 'service']
         ) AS sentiment_result
-      FROM `${var.reviews_topic}`
+      FROM ${local.reviews_fqn}
     )
   SQL
 

--- a/terraform/modules/confluent-flink-ctas/outputs.tf
+++ b/terraform/modules/confluent-flink-ctas/outputs.tf
@@ -8,6 +8,6 @@ output "denormalized_hotel_bookings_table_name" {
 }
 
 output "reviews_with_sentiment_table_name" {
-  description = "Display name of the reviews_with_sentiment materialized table"
-  value       = confluent_flink_materialized_table.reviews_with_sentiment.display_name
+  description = "Display name of the reviews_with_sentiment materialized table (null when disabled)"
+  value       = var.enable_reviews_with_sentiment ? confluent_flink_materialized_table.reviews_with_sentiment[0].display_name : null
 }

--- a/terraform/modules/confluent-flink-ctas/variables.tf
+++ b/terraform/modules/confluent-flink-ctas/variables.tf
@@ -12,8 +12,18 @@ variable "environment_id" {
   type        = string
 }
 
+variable "environment_name" {
+  description = "Confluent environment display name (Flink SQL catalog). Required to fully qualify table refs so dotted CDC topic names like riverhotel.cdc.bookings are not parsed as catalog.database.table."
+  type        = string
+}
+
 variable "kafka_cluster_id" {
   description = "Kafka cluster ID hosting the materialized table backing topics (e.g. lkc-abc123)"
+  type        = string
+}
+
+variable "kafka_cluster_display_name" {
+  description = "Kafka cluster display name (Flink SQL database). Required to fully qualify table refs (same role as sql.current-database on confluent_flink_statement)."
   type        = string
 }
 
@@ -47,6 +57,8 @@ variable "flink_rest_endpoint" {
 # Topic Names
 # ===============================
 # Self-service mode uses plain names; WSA/instructor-led uses CDC prefix.
+# These are the Flink table / Kafka topic names within the catalog.database
+# (not fully qualified). The module wraps them as catalog.database.`topic`.
 
 variable "bookings_topic" {
   description = "Flink table name for bookings data"
@@ -70,4 +82,10 @@ variable "hotel_topic" {
   description = "Flink table name for hotel data"
   type        = string
   default     = "riverhotel.cdc.hotel"
+}
+
+variable "enable_reviews_with_sentiment" {
+  description = "Whether to create the reviews_with_sentiment materialized table (requires AI_SENTIMENT; AWS-only as of 2026-03-19 — https://docs.confluent.io/cloud/current/release-notes/index.html#march-19-2026)"
+  type        = bool
+  default     = true
 }

--- a/terraform/modules/confluent-tableflow-topics/main.tf
+++ b/terraform/modules/confluent-tableflow-topics/main.tf
@@ -2,13 +2,14 @@
 # Confluent Tableflow Topics Module
 # ===============================
 # Enables Tableflow on workshop topics to stream them as Delta Lake
-# tables to S3 via the provider integration. Used by demo mode to
-# automate what self-service users do manually in the CC UI.
+# tables via the provider integration (AWS S3 or Azure ADLS Gen2).
+# Used by demo mode to automate what self-service users do manually
+# in the CC UI.
 #
 # Topics:
-#   1. clickstream                 — raw append-mode data (8-week retention)
-#   2. denormalized_hotel_bookings — enriched bookings (2-week retention)
-#   3. reviews_with_sentiment      — AI-enriched reviews (2-week retention)
+#   1. clickstream                 — raw append-mode data
+#   2. denormalized_hotel_bookings — enriched bookings
+#   3. reviews_with_sentiment      — AI-enriched reviews (optional; AWS only today)
 
 terraform {
   required_providers {
@@ -21,6 +22,11 @@ terraform {
       version = ">= 0.9"
     }
   }
+}
+
+locals {
+  is_aws   = var.cloud_provider == "aws"
+  is_azure = var.cloud_provider == "azure"
 }
 
 # ===============================
@@ -37,7 +43,7 @@ resource "time_sleep" "wait_for_ctas_topics" {
 # ===============================
 # Clickstream — Tableflow
 # ===============================
-# Exists immediately (created by data generator). No wait needed.
+# Exists immediately (created by data generator / CDC). No wait needed.
 
 resource "confluent_tableflow_topic" "clickstream" {
   environment {
@@ -50,9 +56,21 @@ resource "confluent_tableflow_topic" "clickstream" {
   display_name  = var.clickstream_topic
   table_formats = ["DELTA"]
 
-  byob_aws {
-    bucket_name             = var.s3_bucket_name
-    provider_integration_id = var.provider_integration_id
+  dynamic "byob_aws" {
+    for_each = local.is_aws ? [1] : []
+    content {
+      bucket_name             = var.s3_bucket_name
+      provider_integration_id = var.provider_integration_id
+    }
+  }
+
+  dynamic "azure_data_lake_storage_gen_2" {
+    for_each = local.is_azure ? [1] : []
+    content {
+      provider_integration_id = var.provider_integration_id
+      container_name          = var.container_name
+      storage_account_name    = var.storage_account_name
+    }
   }
 
   credentials {
@@ -80,9 +98,21 @@ resource "confluent_tableflow_topic" "denormalized_hotel_bookings" {
   display_name  = "denormalized_hotel_bookings"
   table_formats = ["DELTA"]
 
-  byob_aws {
-    bucket_name             = var.s3_bucket_name
-    provider_integration_id = var.provider_integration_id
+  dynamic "byob_aws" {
+    for_each = local.is_aws ? [1] : []
+    content {
+      bucket_name             = var.s3_bucket_name
+      provider_integration_id = var.provider_integration_id
+    }
+  }
+
+  dynamic "azure_data_lake_storage_gen_2" {
+    for_each = local.is_azure ? [1] : []
+    content {
+      provider_integration_id = var.provider_integration_id
+      container_name          = var.container_name
+      storage_account_name    = var.storage_account_name
+    }
   }
 
   credentials {
@@ -100,8 +130,11 @@ resource "confluent_tableflow_topic" "denormalized_hotel_bookings" {
 # ===============================
 # Reviews with Sentiment — Tableflow
 # ===============================
+# Optional: requires AI_SENTIMENT (not available on Azure as of June 2026).
 
 resource "confluent_tableflow_topic" "reviews_with_sentiment" {
+  count = var.enable_reviews_with_sentiment ? 1 : 0
+
   environment {
     id = var.environment_id
   }
@@ -112,9 +145,21 @@ resource "confluent_tableflow_topic" "reviews_with_sentiment" {
   display_name  = "reviews_with_sentiment"
   table_formats = ["DELTA"]
 
-  byob_aws {
-    bucket_name             = var.s3_bucket_name
-    provider_integration_id = var.provider_integration_id
+  dynamic "byob_aws" {
+    for_each = local.is_aws ? [1] : []
+    content {
+      bucket_name             = var.s3_bucket_name
+      provider_integration_id = var.provider_integration_id
+    }
+  }
+
+  dynamic "azure_data_lake_storage_gen_2" {
+    for_each = local.is_azure ? [1] : []
+    content {
+      provider_integration_id = var.provider_integration_id
+      container_name          = var.container_name
+      storage_account_name    = var.storage_account_name
+    }
   }
 
   credentials {

--- a/terraform/modules/confluent-tableflow-topics/outputs.tf
+++ b/terraform/modules/confluent-tableflow-topics/outputs.tf
@@ -13,6 +13,6 @@ output "denormalized_hotel_bookings_tableflow_id" {
 }
 
 output "reviews_with_sentiment_tableflow_id" {
-  description = "Tableflow topic ID for reviews_with_sentiment"
-  value       = confluent_tableflow_topic.reviews_with_sentiment.id
+  description = "Tableflow topic ID for reviews_with_sentiment (null when disabled)"
+  value       = var.enable_reviews_with_sentiment ? confluent_tableflow_topic.reviews_with_sentiment[0].id : null
 }

--- a/terraform/modules/confluent-tableflow-topics/variables.tf
+++ b/terraform/modules/confluent-tableflow-topics/variables.tf
@@ -12,9 +12,33 @@ variable "kafka_cluster_id" {
   type        = string
 }
 
-variable "s3_bucket_name" {
-  description = "S3 bucket name for Tableflow storage (BYOB)"
+variable "cloud_provider" {
+  description = "Cloud provider for Tableflow BYOB storage (aws or azure)"
   type        = string
+  default     = "aws"
+
+  validation {
+    condition     = contains(["aws", "azure"], var.cloud_provider)
+    error_message = "Must be one of: aws, azure."
+  }
+}
+
+variable "s3_bucket_name" {
+  description = "S3 bucket name for Tableflow storage (BYOB). Required when cloud_provider is aws."
+  type        = string
+  default     = ""
+}
+
+variable "storage_account_name" {
+  description = "Azure storage account name for Tableflow ADLS Gen2 storage. Required when cloud_provider is azure."
+  type        = string
+  default     = ""
+}
+
+variable "container_name" {
+  description = "Azure container name for Tableflow ADLS Gen2 storage. Required when cloud_provider is azure."
+  type        = string
+  default     = ""
 }
 
 variable "provider_integration_id" {
@@ -26,6 +50,12 @@ variable "clickstream_topic" {
   description = "Clickstream topic name"
   type        = string
   default     = "clickstream"
+}
+
+variable "enable_reviews_with_sentiment" {
+  description = "Whether to enable Tableflow on reviews_with_sentiment (requires AI_SENTIMENT; AWS-only as of 2026-03-19 — https://docs.confluent.io/cloud/current/release-notes/index.html#march-19-2026)"
+  type        = bool
+  default     = true
 }
 
 variable "api_key" {

--- a/wsa-spec-aws-demo.yaml
+++ b/wsa-spec-aws-demo.yaml
@@ -1,0 +1,216 @@
+# WSA Spec — AWS Demo
+# Workshop spec for Databricks AWS demo-mode workshops (full pipeline automated).
+# Usage: op run --env-file=.env.tpl -- wsa build -w workshop-tableflow-databricks/wsa-spec-aws-demo.yaml
+# See also: wsa-spec-azure-demo.yaml for the Azure demo variant.
+
+# Workshop metadata
+name: tableflow-databricks-aws-demo
+description: Confluent Cloud + Tableflow + Databricks on AWS (demo mode)
+cloud: AWS # Required: AWS or Azure (GCP support coming later)
+
+# Number of workshop accounts to provision (e.g. tmm+wp1 through tmm+wp95)
+account_count: 95
+
+# Email pattern for workshop accounts. {N} is replaced with the account
+# number (1 through account_count). All emails route to the base address
+# via Gmail + aliasing (e.g. tmm@confluent.io).
+email_pattern: "tmm+wp{N}@confluent.io"
+
+# Terraform source — when terraform_repo is set, wsa clones the repo at runtime.
+# When omitted, wsa uses the local terraform directory relative to this spec file.
+# terraform_repo: https://github.com/confluentinc/workshop-tableflow-databricks
+terraform_path: terraform/aws-demo/ # Demo-mode per-account Terraform (aws-demo/)
+# terraform_ref: main                    # Branch, tag, or commit SHA to clone
+shared_infra_path: terraform/aws-shared/ # Shared infrastructure Terraform directory (deployed once, outputs injected into per-account runs)
+
+# Data generation — defines the engine and data directory used by shared
+# infrastructure to seed the database. wsa copies data_path into the run
+# directory and injects TF_VAR_data_dir so shared infra Terraform can
+# reference data files without hardcoded relative paths.
+data_generation:
+  engine: custom
+  data_path: data/ # copied to run directory (relative to this spec file)
+  config_file: java-datagen-configuration-workshop.json # entrypoint config (relative to data_path)
+
+# Monitoring — always-on CloudWatch-based observability for shared infrastructure.
+# wsa deploys a CloudWatch agent, custom metrics cron job, alarms, SNS email
+# alerts, and a dashboard on the shared EC2 instance. Alert email is derived
+# from TF_VAR_owner_email in wsa.env.
+monitoring:
+  enabled: true
+
+# Pre-destroy cleanup actions run before terraform destroy during wsa clean.
+# Each action is best-effort: warnings are logged but failures don't block destroy.
+cleanup:
+  disable_tableflow: true # Disable all Tableflow topics before terraform destroy (prevents 409 Conflict on provider integration)
+
+# Resource isolation — defines how wsa creates per-attendee isolation
+# boundaries before running the workshop Terraform.
+#
+# Each platform section declares the isolation model. wsa build creates
+# the isolation layer (Phase 1), then runs the workshop Terraform (Phase 2).
+# The workshop Terraform receives pre-created isolation resources as
+# input variables (e.g. databricks_schema, aws_account_tag).
+#
+# Omit the isolation section entirely to skip isolation setup and run
+# the workshop Terraform directly (legacy behavior).
+#
+# Supported models:
+#   databricks:
+#     shared-workspace — one workspace, per-user folders + schemas (cost-efficient)
+#     per-user-workspace — one workspace per attendee (strong, expensive)
+#   aws:
+#     shared-account — single AWS account, resources tagged per attendee
+#
+# Note: Confluent Cloud environment creation is handled by the
+# confluent-platform Terraform module, not by wsa isolation.
+isolation:
+  databricks:
+    model: shared-workspace
+    workspace_name: "workshop-tableflow" # Databricks workspace name
+    workspace_create:
+      false # false: workspace already exists (host from 1Password)
+      # false: workspace must already exist
+    folder: per-user # each user gets /Users/<email>/ (Databricks default)
+    #
+    # workspace_create pros and cons:
+    #
+    #   CREATE (true, default):
+    #     + Fully automated — wsa handles the entire lifecycle
+    #     + Reproducible — workspace is created fresh each time
+    #     + Clean teardown — wsa clean can destroy what it created
+    #     - Workspace creation is slow (~5-15 min, provisions VPC + NAT + S3 in AWS)
+    #     - Requires Databricks account admin access
+    #     - First-run delay (subsequent runs reuse if not cleaned)
+    #
+    #   USE EXISTING (false):
+    #     + Fast — no creation delay; workspace already exists
+    #     + Lower permissions needed (workspace admin, not account admin)
+    #     + Good for shared infrastructure that outlives individual workshops
+    #     - Manual setup required — someone must create the workspace first
+    #     - wsa clean will NOT destroy the workspace (only per-user resources)
+    #     - Risk of state drift if workspace is modified outside of wsa
+    #
+    # Recommendation: Use workspace_create: true for workshops where you want
+    # full lifecycle management. Use false when a long-lived workspace is shared
+    # across multiple workshop types or when account admin access is unavailable.
+    #
+    # Compute: defined in workshop Terraform (shared autoscaling cluster recommended
+    # for 95 concurrent users — e.g. m5.xlarge, 4-10 nodes, autoscale).
+    # AWS EC2 instance limits may need a quota increase for the cluster instance type.
+
+  aws:
+    model: shared-account
+    tag_key: "workshop_account" # tag applied to all resources for this account
+
+# Variables passed to the workshop Terraform via -var flags.
+#
+# When set, ONLY these variables are passed — wsa does not inject its
+# internal names (account_email, etc.).
+# When omitted, wsa falls back to its legacy pass-all behavior.
+#
+# Values support template tokens that are expanded per-account:
+#   {email}              — attendee email (from email_pattern)
+#   {N}                  — raw account number (1, 2, ...)
+#   {NNN}                — zero-padded account number (001, 002, ...)
+#   {dbx_workspace_url}  — from isolation: Databricks workspace URL
+#   {aws_account_tag}    — from isolation: AWS account tag value
+#
+# Literal values (no tokens) are passed as-is to every account.
+terraform_vars:
+  confluent_cloud_email: "{email}"
+  databricks_user_email: "{email}"
+  databricks_sso_email: "wp{N}@tmmconfluentgmail.onmicrosoft.com"
+  environment: "workshop"
+  prefix: "wp{NNN}"
+  table_include_list: "cdc.customer,cdc.hotel,cdc.bookings,cdc.clickstream,cdc.reviews"
+  # cloud_region is set by wsa from wsa.env (TF_VAR_aws_cloud_region / TF_VAR_azure_cloud_region)
+  # cc_environment_id is intentionally omitted — Terraform creates the CC
+  # environment itself (confluent-platform module, create_environment = true).
+
+# Terraform providers used by this workshop (for validation)
+providers:
+  - name: confluent
+    version: ">= 2.0"
+  - name: databricks
+    version: ">= 1.0"
+  - name: aws
+    version: ">= 5.0"
+
+# CLI tools required on the operator's machine (for validation)
+tools_required:
+  - name: terraform
+    version: ">= 1.7"
+  - name: git
+    version: ">= 2.0"
+  - name: op
+    version: ">= 2.0"
+
+# Environment variables that must be set at runtime.
+# These are passed through to Terraform as TF_VAR_* vars.
+# With `op run`, these are resolved from 1Password references in .env.tpl.
+# Databricks vars: use the set matching your cloud (TF_VAR_databricks_aws_* or TF_VAR_databricks_azure_*).
+env_vars:
+  - TF_VAR_confluent_cloud_api_key
+  - TF_VAR_confluent_cloud_api_secret
+  - TF_VAR_databricks_aws_host
+  - TF_VAR_databricks_aws_account_id
+  - TF_VAR_databricks_aws_service_principal_client_id
+  - TF_VAR_databricks_aws_service_principal_client_secret
+  - TF_VAR_aws_access_key_id
+  - TF_VAR_aws_secret_access_key
+
+# Credential groups — define the columns in the CSV output and the
+# sections in the dispenser email. Each group becomes a set of columns
+# with slash-delimited headers (e.g. "Confluent Cloud / Username").
+#
+# Each field has:
+#   label:  Human-readable name (used in CSV header and email)
+#   source: Where the value comes from:
+#     "terraform"   — read from a Terraform root output after apply
+#     "op"          — read from the credential store (set by wsa reset-account-password)
+#     "spec"        — computed from the spec (supports {email}, {account_number} placeholders)
+#   output: (source: terraform only) Name of the Terraform root output
+#   value:  (source: spec only) Template string with placeholders
+#
+# IMPORTANT: For "terraform" source fields, the workshop's Terraform must
+# define matching `output` blocks in the root module. See infra-builder/README.md.
+credentials:
+  - name: Confluent Cloud
+    fields:
+      - label: URL
+        source: terraform
+        output: cc_environment_url
+      - label: Username
+        source: spec
+        value: "{email}"
+      - label: Password
+        source: op
+  - name: Databricks
+    fields:
+      - label: Workspace URL
+        source: terraform
+        output: dbx_workspace_url
+      - label: Username
+        source: spec
+        value: "wp{N}@tmmconfluentgmail.onmicrosoft.com"
+      - label: Password
+        source: op
+      - label: SP Client ID
+        source: terraform
+        output: dbx_sp_client_id
+      - label: SP Client Secret
+        source: terraform
+        output: dbx_sp_client_secret
+      - label: Unity Catalog Name
+        source: terraform
+        output: dbx_catalog_name
+      - label: S3 Bucket Name
+        source: terraform
+        output: s3_bucket_name
+      - label: Schema Name
+        source: terraform
+        output: dbx_schema_name
+      - label: SQL Warehouse ID
+        source: terraform
+        output: dbx_sql_warehouse_id

--- a/wsa-spec-azure-demo.yaml
+++ b/wsa-spec-azure-demo.yaml
@@ -1,0 +1,171 @@
+# WSA Spec — Azure Demo
+# Workshop spec for Databricks Azure demo-mode workshops (full pipeline automated).
+# Usage: op run --env-file=.env.tpl -- wsa build -w workshop-tableflow-databricks/wsa-spec-azure-demo.yaml
+# See also: wsa-spec-aws-demo.yaml for the AWS demo variant.
+
+# Workshop metadata
+name: tableflow-databricks-azure-demo
+description: Confluent Cloud + Tableflow + Databricks on Azure (demo mode)
+cloud: Azure # Required: AWS or Azure (GCP support coming later)
+
+# Number of workshop accounts to provision (e.g. tmm+wp1 through tmm+wp95)
+account_count: 95
+
+# Email pattern for workshop accounts. {N} is replaced with the account
+# number (1 through account_count). All emails route to the base address
+# via Gmail + aliasing (e.g. tmm@confluent.io).
+email_pattern: "tmm+wp{N}@confluent.io"
+
+# Terraform source — when terraform_repo is set, wsa clones the repo at runtime.
+# When omitted, wsa uses the local terraform directory relative to this spec file.
+# terraform_repo: https://github.com/confluentinc/workshop-tableflow-databricks
+terraform_path: terraform/azure-demo/ # Demo-mode per-account Terraform (azure-demo/)
+# terraform_ref: main                         # Branch, tag, or commit SHA to clone
+shared_infra_path: terraform/azure-shared/ # Shared infrastructure Terraform directory (deployed once, outputs injected into per-account runs)
+
+stage_paths:
+  - labs/shared/river_hotel_marketing_agent.ipynb
+
+# Data generation — defines the engine and data directory used by shared
+# infrastructure to seed the database. wsa copies data_path into the run
+# directory and injects TF_VAR_data_dir so shared infra Terraform can
+# reference data files without hardcoded relative paths.
+data_generation:
+  engine: custom
+  data_path: data/ # copied to run directory (relative to this spec file)
+  config_file: java-datagen-configuration-workshop.json # entrypoint config (relative to data_path)
+
+# Monitoring — Azure Monitor-based observability for shared infrastructure.
+# wsa deploys a monitoring agent, custom metrics cron job, alerts, and a
+# dashboard on the shared Azure VM. Alert email is derived from
+# TF_VAR_owner_email in wsa.env.
+monitoring:
+  enabled: true
+
+# Pre-destroy cleanup actions run before terraform destroy during wsa clean.
+# Each action is best-effort: warnings are logged but failures don't block destroy.
+cleanup:
+  disable_tableflow: true # Disable all Tableflow topics before terraform destroy (prevents 409 Conflict on provider integration)
+
+# Resource isolation — defines how wsa creates per-attendee isolation
+# boundaries before running the workshop Terraform.
+#
+# Each platform section declares the isolation model. wsa build creates
+# the isolation layer (Phase 1), then runs the workshop Terraform (Phase 2).
+# The workshop Terraform receives pre-created isolation resources as
+# input variables (e.g. databricks_schema).
+#
+# Supported models:
+#   databricks:
+#     shared-workspace — one workspace, per-user folders + schemas (cost-efficient)
+#
+# Note: Confluent Cloud environment creation is handled by the
+# confluent-platform Terraform module, not by wsa isolation.
+isolation:
+  databricks:
+    model: shared-workspace
+    workspace_name: "workshop-tableflow" # Databricks workspace name
+    workspace_create: false # false: workspace already exists (host from 1Password)
+    folder: per-user # each user gets /Users/<email>/ (Databricks default)
+
+# Variables passed to the workshop Terraform via -var flags.
+#
+# Values support template tokens that are expanded per-account:
+#   {email}              — attendee email (from email_pattern)
+#   {N}                  — raw account number (1, 2, ...)
+#   {NNN}                — zero-padded account number (001, 002, ...)
+#   {dbx_workspace_url}  — from isolation: Databricks workspace URL
+terraform_vars:
+  confluent_cloud_email: "{email}"
+  databricks_user_email: "{email}"
+  databricks_sso_email: "wp{N}@tmmconfluentgmail.onmicrosoft.com"
+  environment: "workshop"
+  prefix: "wp{NNN}"
+  table_include_list: "cdc.customer,cdc.hotel,cdc.bookings,cdc.clickstream,cdc.reviews"
+  # cloud_region is set by wsa from wsa.env (TF_VAR_azure_cloud_region)
+  # cc_environment_id is intentionally omitted — Terraform creates the CC
+  # environment itself (confluent-platform module, create_environment = true).
+
+# Terraform providers used by this workshop (for validation)
+providers:
+  - name: confluent
+    version: ">= 2.0"
+  - name: databricks
+    version: ">= 1.0"
+  - name: azurerm
+    version: ">= 3.0"
+
+# CLI tools required on the operator's machine (for validation)
+tools_required:
+  - name: terraform
+    version: ">= 1.7"
+  - name: git
+    version: ">= 2.0"
+  - name: op
+    version: ">= 2.0"
+
+# Environment variables that must be set at runtime.
+# These are passed through to Terraform as TF_VAR_* vars.
+# With `op run`, these are resolved from 1Password references in .env.tpl.
+#
+# Azure auth: ARM_* env vars are used by the azurerm provider (not TF_VAR_ prefixed).
+# They are set via op run from .env.tpl.
+env_vars:
+  - TF_VAR_confluent_cloud_api_key
+  - TF_VAR_confluent_cloud_api_secret
+  - TF_VAR_databricks_azure_host
+  - TF_VAR_databricks_azure_service_principal_client_id
+  - TF_VAR_databricks_azure_service_principal_client_secret
+  - ARM_TENANT_ID
+  - ARM_CLIENT_ID
+  - ARM_CLIENT_SECRET
+  - ARM_SUBSCRIPTION_ID
+
+# Credential groups — define the columns in the CSV output and the
+# sections in the dispenser email. Each group becomes a set of columns
+# with slash-delimited headers (e.g. "Confluent Cloud / Username").
+#
+# IMPORTANT: For "terraform" source fields, the workshop's Terraform must
+# define matching `output` blocks in the root module.
+credentials:
+  - name: Confluent Cloud
+    fields:
+      - label: URL
+        source: terraform
+        output: cc_environment_url
+      - label: Username
+        source: spec
+        value: "{email}"
+      - label: Password
+        source: op
+  - name: Databricks
+    fields:
+      - label: Workspace URL
+        source: terraform
+        output: dbx_workspace_url
+      - label: Username
+        source: spec
+        value: "wp{N}@tmmconfluentgmail.onmicrosoft.com"
+      - label: Password
+        source: op
+      - label: SP Client ID
+        source: terraform
+        output: dbx_sp_client_id
+      - label: SP Client Secret
+        source: terraform
+        output: dbx_sp_client_secret
+      - label: Unity Catalog Name
+        source: terraform
+        output: dbx_catalog_name
+      - label: Storage Account Name
+        source: terraform
+        output: storage_account_name
+      - label: Storage Container Name
+        source: terraform
+        output: storage_container_name
+      - label: Schema Name
+        source: terraform
+        output: dbx_schema_name
+      - label: SQL Warehouse ID
+        source: terraform
+        output: dbx_sql_warehouse_id


### PR DESCRIPTION
## [0.14.0] - 2026-07-15

### Added

- **Azure Demo Mode**: New `terraform/azure-demo/` root that mirrors AWS demo automation on Azure (catalog integration, `denormalized_hotel_bookings` Flink Materialized Table, Tableflow topic enablement, marketing notebook), with shared-infra / WSA support
- **WSA Demo Specs**: Added `wsa-spec-aws-demo.yaml` and `wsa-spec-azure-demo.yaml` pointing at the demo Terraform roots while keeping shared infra, isolation, and credential output patterns from the workshop specs
- **Tableflow Topics (Azure)**: Extended `confluent-tableflow-topics` with Azure ADLS Gen2 (`azure_data_lake_storage_gen_2`) and an `enable_reviews_with_sentiment` flag
- **Flink CTAS options**: Added `enable_reviews_with_sentiment` to `confluent-flink-ctas` so Azure can skip `AI_SENTIMENT` (AWS-only since 2026-03-19)

### Changed

- **AWS Demo Mode (WSA)**: Upgraded `terraform/aws-demo/` for shared-infra mode (`shared_*` vars, CDC topic wiring, WSA credential outputs) so it works with `wsa build`
- **Flink Materialized Tables**: `confluent-flink-ctas` now fully qualifies source tables as `` `env`.`cluster`.`topic` `` (materialized tables lack `sql.current-catalog` / `sql.current-database`) and selects `check_in`/`check_out` casting by source — `TO_TIMESTAMP_LTZ` for Avro epoch millis (self-service) vs `CAST AS DATE` for CDC `TIMESTAMP_LTZ` (WSA / instructor-led)
- **Docs**: README and `labs/demo` updated for AWS + Azure demo roots (`aws-demo` / `azure-demo`), Azure auth, resource differences, and `AI_SENTIMENT` / `hotel_performance` skip on Azure